### PR TITLE
fix: 修复达到经验上限后停止帮忙不生效

### DIFF
--- a/core/src/services/friend.js
+++ b/core/src/services/friend.js
@@ -161,7 +161,12 @@ function updateOperationLimits(limits) {
                 dayTimes: toNum(limit.day_times),
                 dayTimesLimit: toNum(limit.day_times_lt),
                 dayExpTimes: toNum(limit.day_exp_times),
-                dayExpTimesLimit: toNum(limit.day_exp_times_lt),
+                // proto 字段名: day_ex_times_lt
+                dayExpTimesLimit: toNum(
+                    limit.day_ex_times_lt !== undefined
+                        ? limit.day_ex_times_lt
+                        : limit.day_exp_times_lt
+                ),
             };
             operationLimits.set(id, data);
         }
@@ -176,6 +181,10 @@ function canGetExp(opId) {
     if (!limit) return true;  // 没有限制信息时放行，等待农场检查填充数据
     if (limit.dayExpTimesLimit <= 0) return true;  // 没有经验上限
     return limit.dayExpTimes < limit.dayExpTimesLimit;
+}
+
+function hasAnyHelpExpRoom() {
+    return canGetExp(10005) || canGetExp(10006) || canGetExp(10007);
 }
 
 /**
@@ -227,7 +236,7 @@ async function helpWater(friendGid, landIds, stopWhenExpLimit = false) {
     if (stopWhenExpLimit) {
         await sleep(200);
         const afterExp = toNum((getUserState() || {}).exp);
-        if (afterExp < beforeExp) autoDisableHelpByExpLimit();
+        if (afterExp <= beforeExp) autoDisableHelpByExpLimit();
     }
     return reply;
 }
@@ -244,7 +253,7 @@ async function helpWeed(friendGid, landIds, stopWhenExpLimit = false) {
     if (stopWhenExpLimit) {
         await sleep(200);
         const afterExp = toNum((getUserState() || {}).exp);
-        if (afterExp < beforeExp) autoDisableHelpByExpLimit();
+        if (afterExp <= beforeExp) autoDisableHelpByExpLimit();
     }
     return reply;
 }
@@ -261,7 +270,7 @@ async function helpInsecticide(friendGid, landIds, stopWhenExpLimit = false) {
     if (stopWhenExpLimit) {
         await sleep(200);
         const afterExp = toNum((getUserState() || {}).exp);
-        if (afterExp < beforeExp) autoDisableHelpByExpLimit();
+        if (afterExp <= beforeExp) autoDisableHelpByExpLimit();
     }
     return reply;
 }
@@ -702,6 +711,8 @@ async function visitFriend(friend, totalActions, myGid) {
         // 自动帮忙关闭，直接跳过帮助操作
     } else if (stopWhenExpLimit && !canGetHelpExp) {
         // 今日已达到经验上限后停止帮忙
+    } else if (stopWhenExpLimit && !hasAnyHelpExpRoom()) {
+        autoDisableHelpByExpLimit();
     } else {
         const helpOps = [
             { id: 10005, list: status.needWeed, fn: helpWeed, key: 'weed', name: '草', record: 'helpWeed' },


### PR DESCRIPTION
## 变更说明
本 PR 修复了“达到经验上限后停止帮忙”在部分场景下不生效的问题。

## 问题原因
- 帮忙经验上限字段在 proto 中可能是 `day_ex_times_lt`，原逻辑主要读取 `day_exp_times_lt`，导致部分情况下上限解析不准确。
- 自动关闭判断使用了 `afterExp < beforeExp`，当经验封顶且经验不再增长（前后相等）时不会触发关闭。
- 访问好友流程中，当所有帮忙操作都无法再获取经验时，没有及时主动关闭帮忙。

## 修复内容
- 在 `updateOperationLimits` 中兼容上限字段读取：
  - 优先使用 `day_ex_times_lt`，兼容回退到 `day_exp_times_lt`。
- 新增 `hasAnyHelpExpRoom()`，统一判断 3 类帮忙操作（10005/10006/10007）是否还有经验获取空间。
- 调整 `helpWater` / `helpWeed` / `helpInsecticide` 中的自动关闭判断：
  - 由 `afterExp < beforeExp` 改为 `afterExp <= beforeExp`。
- 在 `visitFriend` 中补充兜底：
  - 当开启“经验上限停止帮忙”且所有帮忙操作都已无经验空间时，主动执行 `autoDisableHelpByExpLimit()`。

## 影响范围
- 文件：`core/src/services/friend.js`
- 影响：达到当日帮忙经验上限后可稳定停止帮忙，避免无效帮忙操作。

## 关联 Issue
Closes #57