### PR TITLE
feat: 下线提醒设置支持单个账户生效和所有账户生效

### DIFF
--- a/core/src/controllers/admin.js
+++ b/core/src/controllers/admin.js
@@ -14,7 +14,7 @@ const { CONFIG } = require('../config/config');
 const { getLevelExpProgress } = require('../config/gameConfig');
 const { getResourcePath } = require('../config/runtime-paths');
 const store = require('../models/store');
-const { addOrUpdateAccount, deleteAccount } = store;
+const { addOrUpdateAccount, deleteAccount, getOfflineReminder, getOfflineReminderForAccount, setOfflineReminder } = store;
 const { findAccountByRef, normalizeAccountRef, resolveAccountId } = require('../services/account-resolver');
 const { createModuleLogger } = require('../services/logger');
 const { MiniProgramLoginSession } = require('../services/qrlogin');
@@ -483,7 +483,20 @@ function startAdminServer(dataProvider) {
     app.post('/api/settings/offline-reminder', async (req, res) => {
         try {
             const body = (req.body && typeof req.body === 'object') ? req.body : {};
-            const data = store.setOfflineReminder ? store.setOfflineReminder(body) : {};
+            const scope = String(body.scope || 'all').trim().toLowerCase();
+            let data;
+            if (scope === 'account') {
+                // 单个账户生效：从 header 或 body 中获取 accountId
+                const rawId = req.headers['x-account-id'] || body._accountId || '';
+                const accountId = String(rawId || '').trim();
+                if (!accountId) {
+                    return res.status(400).json({ ok: false, error: '单账户模式需要提供 x-account-id' });
+                }
+                data = store.setOfflineReminder ? store.setOfflineReminder(body, accountId) : {};
+            } else {
+                // 所有账户生效：保存全局配置
+                data = store.setOfflineReminder ? store.setOfflineReminder(body) : {};
+            }
             res.json({ ok: true, data: data || {} });
         } catch (e) {
             res.status(500).json({ ok: false, error: e.message });
@@ -540,10 +553,16 @@ function startAdminServer(dataProvider) {
             const friendQuietHours = store.getFriendQuietHours(id);
             const automation = store.getAutomation(id);
             const ui = store.getUI();
-            const offlineReminder = store.getOfflineReminder
+            // 优先返回账户级别的下线提醒配置，否则返回全局配置
+            const accountOfflineReminder = id && store.getOfflineReminderForAccount
+                ? store.getOfflineReminderForAccount(id)
+                : null;
+            const globalOfflineReminder = store.getOfflineReminder
                 ? store.getOfflineReminder()
-                : { channel: 'webhook', reloginUrlMode: 'none', endpoint: '', token: '', title: '账号下线提醒', msg: '账号下线', offlineDeleteSec: 120 };
-            res.json({ ok: true, data: { intervals, strategy, preferredSeed, friendQuietHours, automation, ui, offlineReminder } });
+                : { channel: 'webhook', reloginUrlMode: 'none', endpoint: '', token: '', title: '账号下线提醒', msg: '账号下线', offlineDeleteSec: 120, scope: 'all' };
+            // 如果账户有单独配置则返回（scope='account'），否则返回全局配置（scope='all'）
+            const offlineReminder = accountOfflineReminder || globalOfflineReminder;
+            res.json({ ok: true, data: { intervals, strategy, preferredSeed, friendQuietHours, automation, ui, offlineReminder, globalOfflineReminder } });
         } catch (e) {
             res.status(500).json({ ok: false, error: e.message });
         }

--- a/core/src/models/store.js
+++ b/core/src/models/store.js
@@ -24,6 +24,7 @@ const DEFAULT_OFFLINE_REMINDER = {
     title: '账号下线提醒',
     msg: '账号下线',
     offlineDeleteSec: 120,
+    scope: 'all', // 'all' = 所有账户生效, 'account' = 仅指定账户生效
 };
 // ============ 全局配置 ============
 const DEFAULT_ACCOUNT_CONFIG = {
@@ -85,6 +86,7 @@ const globalConfig = {
         theme: 'dark',
     },
     offlineReminder: { ...DEFAULT_OFFLINE_REMINDER },
+    accountOfflineReminders: {}, // key: accountId, value: OfflineReminder
     adminPasswordHash: '',
 };
 
@@ -122,6 +124,10 @@ function normalizeOfflineReminder(input) {
     const msg = (src.msg !== undefined && src.msg !== null)
         ? String(src.msg).trim()
         : DEFAULT_OFFLINE_REMINDER.msg;
+    const rawScope = (src.scope !== undefined && src.scope !== null)
+        ? String(src.scope).trim().toLowerCase()
+        : DEFAULT_OFFLINE_REMINDER.scope;
+    const scope = new Set(['all', 'account']).has(rawScope) ? rawScope : DEFAULT_OFFLINE_REMINDER.scope;
     return {
         channel,
         reloginUrlMode,
@@ -130,6 +136,7 @@ function normalizeOfflineReminder(input) {
         title,
         msg,
         offlineDeleteSec,
+        scope,
     };
 }
 
@@ -287,6 +294,16 @@ function loadGlobalConfig() {
             const theme = String(globalConfig.ui.theme || '').toLowerCase();
             globalConfig.ui.theme = theme === 'light' ? 'light' : 'dark';
             globalConfig.offlineReminder = normalizeOfflineReminder(data.offlineReminder);
+            // 加载账户级别下线提醒配置
+            const accReminders = (data.accountOfflineReminders && typeof data.accountOfflineReminders === 'object')
+                ? data.accountOfflineReminders
+                : {};
+            globalConfig.accountOfflineReminders = {};
+            for (const [id, cfg] of Object.entries(accReminders)) {
+                const sid = String(id || '').trim();
+                if (!sid) continue;
+                globalConfig.accountOfflineReminders[sid] = normalizeOfflineReminder(cfg);
+            }
             if (typeof data.adminPasswordHash === 'string') {
                 globalConfig.adminPasswordHash = data.adminPasswordHash;
             }
@@ -312,6 +329,18 @@ function sanitizeGlobalConfigBeforeSave() {
         nextMap[sid] = normalizeAccountConfig(cfg, accountFallbackConfig);
     }
     globalConfig.accountConfigs = nextMap;
+
+    // 账户级下线提醒配置统一净化
+    const reminderMap = (globalConfig.accountOfflineReminders && typeof globalConfig.accountOfflineReminders === 'object')
+        ? globalConfig.accountOfflineReminders
+        : {};
+    const nextReminderMap = {};
+    for (const [id, cfg] of Object.entries(reminderMap)) {
+        const sid = String(id || '').trim();
+        if (!sid) continue;
+        nextReminderMap[sid] = normalizeOfflineReminder(cfg);
+    }
+    globalConfig.accountOfflineReminders = nextReminderMap;
 }
 
 // 保存全局配置
@@ -507,11 +536,36 @@ function setUITheme(theme) {
     return applyConfigSnapshot({ ui: { theme: next } });
 }
 
-function getOfflineReminder() {
+function getOfflineReminder(accountId) {
+    const id = accountId ? String(accountId).trim() : '';
+    if (id && globalConfig.accountOfflineReminders && globalConfig.accountOfflineReminders[id]) {
+        return normalizeOfflineReminder(globalConfig.accountOfflineReminders[id]);
+    }
     return normalizeOfflineReminder(globalConfig.offlineReminder);
 }
 
-function setOfflineReminder(cfg) {
+function getOfflineReminderForAccount(accountId) {
+    const id = accountId ? String(accountId).trim() : '';
+    if (!id) return null;
+    if (globalConfig.accountOfflineReminders && globalConfig.accountOfflineReminders[id]) {
+        return normalizeOfflineReminder(globalConfig.accountOfflineReminders[id]);
+    }
+    return null; // 未单独配置
+}
+
+function setOfflineReminder(cfg, accountId) {
+    const id = accountId ? String(accountId).trim() : '';
+    if (id) {
+        // 保存账户级别配置
+        const current = (globalConfig.accountOfflineReminders && globalConfig.accountOfflineReminders[id])
+            ? normalizeOfflineReminder(globalConfig.accountOfflineReminders[id])
+            : normalizeOfflineReminder(globalConfig.offlineReminder);
+        if (!globalConfig.accountOfflineReminders) globalConfig.accountOfflineReminders = {};
+        globalConfig.accountOfflineReminders[id] = normalizeOfflineReminder({ ...current, ...(cfg || {}) });
+        saveGlobalConfig();
+        return normalizeOfflineReminder(globalConfig.accountOfflineReminders[id]);
+    }
+    // 保存全局配置
     const current = normalizeOfflineReminder(globalConfig.offlineReminder);
     globalConfig.offlineReminder = normalizeOfflineReminder({ ...current, ...(cfg || {}) });
     saveGlobalConfig();
@@ -602,6 +656,7 @@ module.exports = {
     getUI,
     setUITheme,
     getOfflineReminder,
+    getOfflineReminderForAccount,
     setOfflineReminder,
     getAccounts,
     addOrUpdateAccount,

--- a/core/src/runtime/relogin-reminder.js
+++ b/core/src/runtime/relogin-reminder.js
@@ -133,8 +133,27 @@ function createReloginReminderService(options) {
 
     async function triggerOfflineReminder(payload = {}) {
         try {
-            const cfg = store.getOfflineReminder ? store.getOfflineReminder() : null;
-            if (!cfg) return;
+            const triggerAccountId = String(payload.accountId || '').trim();
+
+            // 先查账户级别专属配置（scope='account' 的单账户配置）
+            let cfg = null;
+            if (triggerAccountId && store.getOfflineReminderForAccount) {
+                cfg = store.getOfflineReminderForAccount(triggerAccountId);
+                // 账户级配置 scope 必须是 'account' 才生效
+                if (cfg && String(cfg.scope || 'all').trim().toLowerCase() !== 'account') {
+                    cfg = null;
+                }
+            }
+
+            // 账户级配置不存在则使用全局配置
+            if (!cfg) {
+                const globalCfg = store.getOfflineReminder ? store.getOfflineReminder() : null;
+                if (!globalCfg) return;
+                const globalScope = String(globalCfg.scope || 'all').trim().toLowerCase();
+                // 全局配置 scope='all' 才对所有账户生效；scope='account' 的全局配置不触发
+                if (globalScope !== 'all') return;
+                cfg = globalCfg;
+            }
 
             const channelName = String(cfg.channel || '').trim().toLowerCase();
             const reloginUrlMode = String(cfg.reloginUrlMode || 'none').trim().toLowerCase();

--- a/web/src/stores/setting.ts
+++ b/web/src/stores/setting.ts
@@ -43,6 +43,7 @@ export interface OfflineConfig {
   title: string
   msg: string
   offlineDeleteSec: number
+  scope: 'all' | 'account' // 'all'=所有账户生效, 'account'=仅当前账户生效
 }
 
 export interface UIConfig {
@@ -57,9 +58,21 @@ export interface SettingsState {
   automation: AutomationConfig
   ui: UIConfig
   offlineReminder: OfflineConfig
+  globalOfflineReminder: OfflineConfig // 全局下线提醒配置（不受账户级覆盖）
 }
 
 export const useSettingStore = defineStore('setting', () => {
+  const defaultOfflineReminder: OfflineConfig = {
+    channel: 'webhook',
+    reloginUrlMode: 'none',
+    endpoint: '',
+    token: '',
+    title: '账号下线提醒',
+    msg: '账号下线',
+    offlineDeleteSec: 120,
+    scope: 'all' as 'all' | 'account',
+  }
+
   const settings = ref<SettingsState>({
     plantingStrategy: 'preferred',
     preferredSeedId: 0,
@@ -67,15 +80,8 @@ export const useSettingStore = defineStore('setting', () => {
     friendQuietHours: { enabled: false, start: '23:00', end: '07:00' },
     automation: {},
     ui: {},
-    offlineReminder: {
-      channel: 'webhook',
-      reloginUrlMode: 'none',
-      endpoint: '',
-      token: '',
-      title: '账号下线提醒',
-      msg: '账号下线',
-      offlineDeleteSec: 120,
-    },
+    offlineReminder: { ...defaultOfflineReminder },
+    globalOfflineReminder: { ...defaultOfflineReminder },
   })
   const loading = ref(false)
 
@@ -95,15 +101,8 @@ export const useSettingStore = defineStore('setting', () => {
         settings.value.friendQuietHours = d.friendQuietHours || { enabled: false, start: '23:00', end: '07:00' }
         settings.value.automation = d.automation || {}
         settings.value.ui = d.ui || {}
-        settings.value.offlineReminder = d.offlineReminder || {
-          channel: 'webhook',
-          reloginUrlMode: 'none',
-          endpoint: '',
-          token: '',
-          title: '账号下线提醒',
-          msg: '账号下线',
-          offlineDeleteSec: 120,
-        }
+        settings.value.offlineReminder = d.offlineReminder || { ...defaultOfflineReminder }
+        settings.value.globalOfflineReminder = d.globalOfflineReminder || d.offlineReminder || { ...defaultOfflineReminder }
       }
     }
     finally {
@@ -144,10 +143,14 @@ export const useSettingStore = defineStore('setting', () => {
     }
   }
 
-  async function saveOfflineConfig(config: OfflineConfig) {
+  async function saveOfflineConfig(config: OfflineConfig, accountId?: string) {
     loading.value = true
     try {
-      const { data } = await api.post('/api/settings/offline-reminder', config)
+      const headers: Record<string, string> = {}
+      if (config.scope === 'account' && accountId) {
+        headers['x-account-id'] = accountId
+      }
+      const { data } = await api.post('/api/settings/offline-reminder', config, { headers })
       if (data && data.ok) {
         settings.value.offlineReminder = config
         return { ok: true }

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -87,6 +87,7 @@ const localOffline = ref({
   title: '',
   msg: '',
   offlineDeleteSec: 120,
+  scope: 'all' as 'all' | 'account',
 })
 
 const passwordForm = ref({
@@ -166,7 +167,7 @@ function syncLocalSettings() {
       }
     }
 
-    // Sync offline settings (global)
+    // Sync offline settings（账户有专属配置则显示专属配置，否则显示全局配置）
     if (settings.value.offlineReminder) {
       localOffline.value = JSON.parse(JSON.stringify(settings.value.offlineReminder))
     }
@@ -381,9 +382,16 @@ async function handleChangePassword() {
 }
 
 async function handleSaveOffline() {
+  if (localOffline.value.scope === 'account' && !currentAccountId.value) {
+    showAlert('请先选择要配置的账号', 'danger')
+    return
+  }
   offlineSaving.value = true
   try {
-    const res = await settingStore.saveOfflineConfig(localOffline.value)
+    const res = await settingStore.saveOfflineConfig(
+      localOffline.value,
+      localOffline.value.scope === 'account' ? currentAccountId.value || undefined : undefined,
+    )
 
     if (res.ok) {
       showAlert('下线提醒设置已保存')
@@ -658,6 +666,42 @@ async function handleTestOffline() {
 
         <!-- Offline Content -->
         <div class="flex-1 p-4 space-y-3">
+          <!-- 生效范围 -->
+          <div class="flex items-center gap-3 border border-blue-200 rounded-lg bg-blue-50 px-3 py-2 dark:border-blue-800 dark:bg-blue-900/20">
+            <div class="i-carbon-user-multiple shrink-0 text-blue-500" />
+            <div class="flex flex-1 flex-wrap items-center gap-3">
+              <span class="text-sm text-gray-700 font-medium dark:text-gray-300">生效范围</span>
+              <div class="flex gap-3">
+                <label class="flex cursor-pointer items-center gap-1.5 text-sm">
+                  <input
+                    v-model="localOffline.scope"
+                    type="radio"
+                    value="all"
+                    class="accent-blue-500"
+                  >
+                  <span class="text-gray-700 dark:text-gray-300">所有账户</span>
+                </label>
+                <label class="flex cursor-pointer items-center gap-1.5 text-sm">
+                  <input
+                    v-model="localOffline.scope"
+                    type="radio"
+                    value="account"
+                    class="accent-blue-500"
+                    :disabled="!currentAccountId"
+                  >
+                  <span
+                    class="dark:text-gray-300"
+                    :class="currentAccountId ? 'text-gray-700' : 'text-gray-400 dark:text-gray-500'"
+                  >
+                    仅当前账户
+                    <span v-if="currentAccountName && localOffline.scope === 'account'" class="ml-1 text-blue-500">({{ currentAccountName }})</span>
+                    <span v-else-if="!currentAccountId" class="ml-1 text-xs text-gray-400">(需先选择账户)</span>
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+
           <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
             <div class="flex flex-col gap-1.5">
               <div class="flex items-center justify-between">


### PR DESCRIPTION
- store.js: 新增 accountOfflineReminders map，存储账户级下线提醒配置； normalizeOfflineReminder 增加 scope 字段（'all'|'account'）； loadGlobalConfig/sanitizeGlobalConfigBeforeSave 统一处理账户级配置； getOfflineReminder 支持按 accountId 查询（账户专属优先）； 新增 getOfflineReminderForAccount（仅返回账户专属配置）
- admin.js: POST /api/settings/offline-reminder 支持 scope='account' 时 按 x-account-id 保存账户级配置；GET /api/settings 返回 offlineReminder 和 globalOfflineReminder 两个字段
- relogin-reminder.js: triggerOfflineReminder 先查账户专属配置， 无则查全局配置（scope='all' 才触发，scope='account' 不触发）
- setting.ts: OfflineConfig 增加 scope 字段；SettingsState 增加 globalOfflineReminder；saveOfflineConfig 支持传 accountId
- Settings.vue: 下线提醒表单增加生效范围单选控件（所有账户/仅当前账户）