### PR TITLE
fix: 好友巡查 SyncAll 接口 + UnoCSS Carbon 图标配置

### DIFF
--- a/core/src/services/friend.js
+++ b/core/src/services/friend.js
@@ -114,9 +114,9 @@ function addFriendToBlacklist(friendGid, friendName, reason = '') {
 // ============ 好友 API ============
 
 async function getAllFriends() {
-    const body = types.GetAllFriendsRequest.encode(types.GetAllFriendsRequest.create({})).finish();
-    const { body: replyBody } = await sendMsgAsync('gamepb.friendpb.FriendService', 'GetAll', body);
-    return types.GetAllFriendsReply.decode(replyBody);
+    const body = types.SyncAllRequest.encode(types.SyncAllRequest.create({ open_ids: [] })).finish();
+    const { body: replyBody } = await sendMsgAsync('gamepb.friendpb.FriendService', 'SyncAll', body);
+    return types.SyncAllReply.decode(replyBody);
 }
 
 // ============ 好友申请 API (微信同玩) ============

--- a/core/src/utils/proto.js
+++ b/core/src/utils/proto.js
@@ -106,6 +106,8 @@ const typeMappings = [
     // 好友
     ['GetAllFriendsRequest', 'gamepb.friendpb.GetAllRequest'],
     ['GetAllFriendsReply', 'gamepb.friendpb.GetAllReply'],
+    ['SyncAllRequest', 'gamepb.friendpb.SyncAllRequest'],
+    ['SyncAllReply', 'gamepb.friendpb.SyncAllReply'],
     ['GetApplicationsRequest', 'gamepb.friendpb.GetApplicationsRequest'],
     ['GetApplicationsReply', 'gamepb.friendpb.GetApplicationsReply'],
     ['AcceptFriendsRequest', 'gamepb.friendpb.AcceptFriendsRequest'],

--- a/web/uno.config.ts
+++ b/web/uno.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
       warn: true,
       collections: {
         fas: () => import('@iconify-json/fa-solid/icons.json').then(i => i.default),
+        carbon: () => import('@iconify-json/carbon/icons.json').then(i => i.default),
+        'svg-spinners': () => import('@iconify-json/svg-spinners/icons.json').then(i => i.default),
       },
     }),
   ],


### PR DESCRIPTION
- 好友巡查: 使用 SyncAll/SyncAllRequest 替代 GetAll，传入 open_ids 修复参数错误
- proto: 添加 SyncAllRequest/SyncAllReply 类型映射
- web: 配置 Carbon 和 svg-spinners 图标集，修复主题切换按钮图标不显示
