### PR TITLE
fix:种子占用多块地判断问题

### DIFF
--- a/core/src/services/farm.js
+++ b/core/src/services/farm.js
@@ -4,7 +4,7 @@
 
 const protobuf = require('protobufjs');
 const { CONFIG, PlantPhase, PHASE_NAMES } = require('../config/config');
-const { getPlantNameBySeedId, getPlantName, getPlantExp, formatGrowTime, getPlantGrowTime, getAllSeeds, getPlantById, getSeedImageBySeedId } = require('../config/gameConfig');
+const { getPlantNameBySeedId, getPlantName, getPlantExp, formatGrowTime, getPlantGrowTime, getAllSeeds, getPlantById, getPlantBySeedId, getSeedImageBySeedId } = require('../config/gameConfig');
 const { isAutomationOn, getPreferredSeed, getAutomation, getPlantingStrategy } = require('../models/store');
 const { sendMsgAsync, getUserState, networkEvents, getWsErrorState } = require('../utils/network');
 const { types } = require('../utils/proto');
@@ -161,6 +161,83 @@ function getOrganicFertilizerTargetsFromLands(lands) {
         targets.push(landId);
     }
     return targets;
+}
+
+function getSlaveLandIds(land) {
+    const ids = Array.isArray(land && land.slave_land_ids) ? land.slave_land_ids : [];
+    return [...new Set(ids.map(id => toNum(id)).filter(Boolean))];
+}
+
+function hasPlantData(land) {
+    const plant = land && land.plant;
+    return !!(plant && Array.isArray(plant.phases) && plant.phases.length > 0);
+}
+
+function getLinkedMasterLand(land, landsMap) {
+    const landId = toNum(land && land.id);
+    const masterLandId = toNum(land && land.master_land_id);
+    if (!masterLandId || masterLandId === landId) return null;
+
+    const masterLand = landsMap.get(masterLandId);
+    if (!masterLand) return null;
+
+    const slaveIds = getSlaveLandIds(masterLand);
+    if (slaveIds.length > 0 && !slaveIds.includes(landId)) return null;
+
+    return masterLand;
+}
+
+function getDisplayLandContext(land, landsMap) {
+    const masterLand = getLinkedMasterLand(land, landsMap);
+    if (masterLand && hasPlantData(masterLand)) {
+        const occupiedLandIds = [toNum(masterLand.id), ...getSlaveLandIds(masterLand)].filter(Boolean);
+        return {
+            sourceLand: masterLand,
+            occupiedByMaster: true,
+            masterLandId: toNum(masterLand.id),
+            occupiedLandIds: occupiedLandIds.length > 0 ? occupiedLandIds : [toNum(masterLand.id)].filter(Boolean),
+        };
+    }
+
+    const selfId = toNum(land && land.id);
+    return {
+        sourceLand: land,
+        occupiedByMaster: false,
+        masterLandId: selfId,
+        occupiedLandIds: [selfId].filter(Boolean),
+    };
+}
+
+function isOccupiedSlaveLand(land, landsMap) {
+    return !!getDisplayLandContext(land, landsMap).occupiedByMaster;
+}
+
+function summarizeLandDetails(lands) {
+    const summary = {
+        harvestable: 0,
+        growing: 0,
+        empty: 0,
+        dead: 0,
+        needWater: 0,
+        needWeed: 0,
+        needBug: 0,
+    };
+
+    for (const land of Array.isArray(lands) ? lands : []) {
+        if (!land || !land.unlocked) continue;
+
+        const status = String(land.status || '');
+        if (status === 'harvestable') summary.harvestable++;
+        else if (status === 'dead') summary.dead++;
+        else if (status === 'empty') summary.empty++;
+        else if (status === 'growing' || status === 'stealable' || status === 'harvested') summary.growing++;
+
+        if (land.needWater) summary.needWater++;
+        if (land.needWeed) summary.needWeed++;
+        if (land.needBug) summary.needBug++;
+    }
+
+    return summary;
 }
 
 const ALL_FERTILIZER_LAND_TYPES = ['gold', 'black', 'red', 'normal'];
@@ -378,23 +455,54 @@ function encodePlantRequest(seedId, landIds) {
     return writer.finish();
 }
 
+function getPlantSizeBySeedId(seedId) {
+    const plantCfg = getPlantBySeedId(toNum(seedId));
+    return Math.max(1, toNum(plantCfg && plantCfg.size) || 1);
+}
+
 /**
  * 种植 - 游戏中拖动种植间隔很短，这里用 50ms
  */
-async function plantSeeds(seedId, landIds) {
+async function plantSeeds(seedId, landIds, options = {}) {
     let successCount = 0;
-    for (const landId of landIds) {
+    const plantedLandIds = [];
+    const occupiedLandIds = new Set();
+    const maxPlantCount = Math.max(0, toNum(options.maxPlantCount) || 0) || Number.POSITIVE_INFINITY;
+    const pendingLandIds = new Set((Array.isArray(landIds) ? landIds : []).map(id => toNum(id)).filter(Boolean));
+
+    for (const rawLandId of landIds) {
+        const landId = toNum(rawLandId);
+        if (!landId || !pendingLandIds.has(landId)) continue;
+        if (successCount >= maxPlantCount) break;
+
         try {
             const body = encodePlantRequest(seedId, [landId]);
             const { body: replyBody } = await sendMsgAsync('gamepb.plantpb.PlantService', 'Plant', body);
-            types.PlantReply.decode(replyBody);
+            const reply = types.PlantReply.decode(replyBody);
+            const changedLands = Array.isArray(reply && reply.land) ? reply.land : [];
+            const changedMap = buildLandMap(changedLands);
+            const selfLand = changedMap.get(landId);
+            const displayContext = getDisplayLandContext(selfLand || { id: landId }, changedMap);
+            const occupiedIds = displayContext.occupiedLandIds.length > 0
+                ? displayContext.occupiedLandIds
+                : [landId];
+
             successCount++;
+            plantedLandIds.push(displayContext.masterLandId || landId);
+            for (const occupiedId of occupiedIds) {
+                occupiedLandIds.add(occupiedId);
+                pendingLandIds.delete(occupiedId);
+            }
         } catch (e) {
             logWarn('种植', `土地#${landId} 失败: ${e.message}`);
         }
         if (landIds.length > 1) await sleep(50);  // 50ms 间隔
     }
-    return successCount;
+    return {
+        planted: successCount,
+        plantedLandIds,
+        occupiedLandIds: [...occupiedLandIds],
+    };
 }
 
 async function findBestSeed() {
@@ -555,8 +663,8 @@ async function getLandsDetail() {
     try {
         const landsReply = await getAllLands();
         if (!landsReply.lands) return { lands: [], summary: {} };
-        const status = analyzeLands(landsReply.lands);
         const nowSec = getServerTimeSec();
+        const landsMap = buildLandMap(landsReply.lands);
         const lands = [];
 
         for (const land of landsReply.lands) {
@@ -567,6 +675,12 @@ async function getLandsDetail() {
             const landSize = toNum(land.land_size);
             const couldUnlock = !!land.could_unlock;
             const couldUpgrade = !!land.could_upgrade;
+            const {
+                sourceLand,
+                occupiedByMaster,
+                masterLandId,
+                occupiedLandIds,
+            } = getDisplayLandContext(land, landsMap);
             if (!land.unlocked) {
                 lands.push({
                     id,
@@ -582,10 +696,14 @@ async function getLandsDetail() {
                     couldUpgrade,
                     currentSeason: 0,
                     totalSeason: 0,
+                    occupiedByMaster: false,
+                    masterLandId: 0,
+                    occupiedLandIds: [],
+                    plantSize: 1,
                 });
                 continue;
             }
-            const plant = land.plant;
+            const plant = sourceLand && sourceLand.plant;
             if (!plant || !plant.phases || plant.phases.length === 0) {
                 lands.push({
                     id,
@@ -601,6 +719,10 @@ async function getLandsDetail() {
                     couldUpgrade,
                     currentSeason: 0,
                     totalSeason: 0,
+                    occupiedByMaster,
+                    masterLandId,
+                    occupiedLandIds,
+                    plantSize: 1,
                 });
                 continue;
             }
@@ -620,6 +742,10 @@ async function getLandsDetail() {
                     couldUpgrade,
                     currentSeason: 0,
                     totalSeason: 0,
+                    occupiedByMaster,
+                    masterLandId,
+                    occupiedLandIds,
+                    plantSize: 1,
                 });
                 continue;
             }
@@ -629,6 +755,7 @@ async function getLandsDetail() {
             const plantCfg = getPlantById(plantId);
             const seedId = toNum(plantCfg && plantCfg.seed_id);
             const seedImage = seedId > 0 ? getSeedImageBySeedId(seedId) : '';
+            const plantSize = Math.max(1, toNum(plantCfg && plantCfg.size) || 1);
             const totalSeason = Math.max(1, toNum(plantCfg && plantCfg.seasons) || 1);
             const currentSeasonRaw = toNum(plant.season);
             const currentSeason = currentSeasonRaw > 0 ? Math.min(currentSeasonRaw, totalSeason) : 1;
@@ -669,20 +796,16 @@ async function getLandsDetail() {
                 landSize,
                 couldUnlock,
                 couldUpgrade,
+                occupiedByMaster,
+                masterLandId,
+                occupiedLandIds,
+                plantSize,
             });
         }
 
         return {
             lands,
-            summary: {
-                harvestable: status.harvestable.length,
-                growing: status.growing.length,
-                empty: status.empty.length,
-                dead: status.dead.length,
-                needWater: status.needWater.length,
-                needWeed: status.needWeed.length,
-                needBug: status.needBug.length,
-            },
+            summary: summarizeLandDetails(lands),
         };
     } catch {
         return { lands: [], summary: {} };
@@ -725,12 +848,28 @@ async function autoPlantEmptyLands(deadLandIds, emptyLandIds) {
     const seedName = getPlantNameBySeedId(bestSeed.seedId);
     const growTime = getPlantGrowTime(1020000 + (bestSeed.seedId - 20000));  // 转换为植物ID
     const growTimeStr = growTime > 0 ? ` 生长${formatGrowTime(growTime)}` : '';
+    const plantSize = getPlantSizeBySeedId(bestSeed.seedId);
+    const landFootprint = plantSize * plantSize;
     log('商店', `最佳种子: ${seedName} (${bestSeed.seedId}) 价格=${bestSeed.price}金币${growTimeStr}`, {
         module: 'warehouse', event: 'seed_pick', seedId: bestSeed.seedId, price: bestSeed.price
     });
 
     // 3. 购买
-    const needCount = landsToPlant.length;
+    let needCount = landsToPlant.length;
+    if (landFootprint > 1) {
+        needCount = Math.floor(landsToPlant.length / landFootprint);
+        if (needCount <= 0) {
+            log('种植', `${seedName} 需要至少 ${landFootprint} 块空地才能合并种植，当前仅 ${landsToPlant.length} 块可用，已跳过`, {
+                module: 'farm',
+                event: 'plant_seed',
+                result: 'skip',
+                seedId: bestSeed.seedId,
+                landFootprint,
+                emptyCount: landsToPlant.length,
+            });
+            return;
+        }
+    }
     const totalCost = bestSeed.price * needCount;
     if (totalCost > state.gold) {
         logWarn('商店', `金币不足! 需要 ${totalCost} 金币, 当前 ${state.gold} 金币`, {
@@ -738,13 +877,13 @@ async function autoPlantEmptyLands(deadLandIds, emptyLandIds) {
         });
         const canBuy = Math.floor(state.gold / bestSeed.price);
         if (canBuy <= 0) return;
-        landsToPlant = landsToPlant.slice(0, canBuy);
-        log('商店', `金币有限，只种 ${canBuy} 块地`);
+        needCount = canBuy;
+        log('商店', plantSize > 1 ? `金币有限，只尝试种植 ${canBuy} 组 ${plantSize}x${plantSize} 作物` : `金币有限，只种 ${canBuy} 块地`);
     }
 
     let actualSeedId = bestSeed.seedId;
     try {
-        const buyReply = await buyGoods(bestSeed.goodsId, landsToPlant.length, bestSeed.price);
+        const buyReply = await buyGoods(bestSeed.goodsId, needCount, bestSeed.price);
         if (buyReply.get_items && buyReply.get_items.length > 0) {
             const gotItem = buyReply.get_items[0];
             const gotId = toNum(gotItem.id);
@@ -756,13 +895,13 @@ async function autoPlantEmptyLands(deadLandIds, emptyLandIds) {
             }
         }
         const boughtName = getPlantNameBySeedId(actualSeedId);
-        log('购买', `已购买 ${boughtName}种子 x${landsToPlant.length}, 花费 ${bestSeed.price * landsToPlant.length} 金币`, {
+        log('购买', `已购买 ${boughtName}种子 x${needCount}, 花费 ${bestSeed.price * needCount} 金币`, {
             module: 'warehouse',
             event: 'seed_buy',
             result: 'ok',
             seedId: actualSeedId,
-            count: landsToPlant.length,
-            cost: bestSeed.price * landsToPlant.length,
+            count: needCount,
+            cost: bestSeed.price * needCount,
         });
     } catch (e) {
         logWarn('购买', e.message);
@@ -772,16 +911,20 @@ async function autoPlantEmptyLands(deadLandIds, emptyLandIds) {
     // 4. 种植（逐块拖动，间隔50ms）
     let plantedLands = [];
     try {
-        const planted = await plantSeeds(actualSeedId, landsToPlant);
-        log('种植', `已在 ${planted} 块地种植 (${landsToPlant.join(',')})`, {
+        const { planted, plantedLandIds, occupiedLandIds } = await plantSeeds(actualSeedId, landsToPlant, { maxPlantCount: needCount });
+        const occupiedCount = occupiedLandIds.length > 0 ? occupiedLandIds.length : planted;
+        log('种植', plantSize > 1
+            ? `已种植 ${planted} 组 ${plantSize}x${plantSize} 作物，占用 ${occupiedCount} 块地 (${occupiedLandIds.join(',')})`
+            : `已在 ${planted} 块地种植 (${landsToPlant.slice(0, planted).join(',')})`, {
             module: 'farm',
             event: 'plant_seed',
             result: 'ok',
             seedId: actualSeedId,
             count: planted,
+            occupiedCount,
         });
         if (planted > 0) {
-            plantedLands = landsToPlant.slice(0, planted);
+            plantedLands = plantedLandIds;
         }
     } catch (e) {
         logWarn('种植', e.message);
@@ -833,6 +976,7 @@ function analyzeLands(lands) {
 
     const nowSec = getServerTimeSec();
     const debug = isFirstFarmCheck;
+    const landsMap = buildLandMap(lands);
 
     for (const land of lands) {
         const id = toNum(land.id);
@@ -844,6 +988,10 @@ function analyzeLands(lands) {
         }
         if (land.could_upgrade) {
             result.upgradable.push(id);
+        }
+
+        if (isOccupiedSlaveLand(land, landsMap)) {
+            continue;
         }
 
         const plant = land.plant;
@@ -1286,4 +1434,7 @@ module.exports = {
     getAvailableSeeds,
     runFarmOperation, // 导出新函数
     runFertilizerByConfig,
+    buildLandMap,
+    getDisplayLandContext,
+    isOccupiedSlaveLand,
 };

--- a/core/src/services/friend.js
+++ b/core/src/services/friend.js
@@ -9,7 +9,7 @@ const { isAutomationOn, getFriendQuietHours, getFriendBlacklist } = require('../
 const { sendMsgAsync, getUserState, networkEvents } = require('../utils/network');
 const { types } = require('../utils/proto');
 const { toLong, toNum, toTimeSec, getServerTimeSec, log, logWarn, sleep } = require('../utils/utils');
-const { getCurrentPhase, setOperationLimitsCallback } = require('./farm');
+const { getCurrentPhase, setOperationLimitsCallback, buildLandMap, getDisplayLandContext, isOccupiedSlaveLand } = require('./farm');
 const { createScheduler } = require('./scheduler');
 const { recordOperation } = require('./stats');
 const { sellAllFruits } = require('./warehouse');
@@ -434,8 +434,14 @@ function analyzeFriendLands(lands, myGid, friendName = '') {
         canPutBug: [],   // 可以放虫
     };
 
+    const landsMap = buildLandMap(lands);
+
     for (const land of lands) {
         const id = toNum(land.id);
+        if (isOccupiedSlaveLand(land, landsMap)) {
+            continue;
+        }
+
         const plant = land.plant;
 
         if (!plant || !plant.phases || plant.phases.length === 0) {
@@ -530,10 +536,17 @@ async function getFriendLandsDetail(friendGid) {
 
         const landsList = [];
         const nowSec = getServerTimeSec();
+        const landsMap = buildLandMap(lands);
         for (const land of lands) {
             const id = toNum(land.id);
             const level = toNum(land.level);
             const unlocked = !!land.unlocked;
+            const {
+                sourceLand,
+                occupiedByMaster,
+                masterLandId,
+                occupiedLandIds,
+            } = getDisplayLandContext(land, landsMap);
             if (!unlocked) {
                 landsList.push({
                     id,
@@ -545,17 +558,43 @@ async function getFriendLandsDetail(friendGid) {
                     needWater: false,
                     needWeed: false,
                     needBug: false,
+                    occupiedByMaster: false,
+                    masterLandId: 0,
+                    occupiedLandIds: [],
+                    plantSize: 1,
                 });
                 continue;
             }
-            const plant = land.plant;
+            const plant = sourceLand && sourceLand.plant;
             if (!plant || !plant.phases || plant.phases.length === 0) {
-                landsList.push({ id, unlocked: true, status: 'empty', plantName: '', phaseName: '空地', level });
+                landsList.push({
+                    id,
+                    unlocked: true,
+                    status: 'empty',
+                    plantName: '',
+                    phaseName: '空地',
+                    level,
+                    occupiedByMaster,
+                    masterLandId,
+                    occupiedLandIds,
+                    plantSize: 1,
+                });
                 continue;
             }
             const currentPhase = getCurrentPhase(plant.phases, false, '');
             if (!currentPhase) {
-                landsList.push({ id, unlocked: true, status: 'empty', plantName: '', phaseName: '', level });
+                landsList.push({
+                    id,
+                    unlocked: true,
+                    status: 'empty',
+                    plantName: '',
+                    phaseName: '',
+                    level,
+                    occupiedByMaster,
+                    masterLandId,
+                    occupiedLandIds,
+                    plantSize: 1,
+                });
                 continue;
             }
             const phaseVal = currentPhase.phase;
@@ -564,6 +603,7 @@ async function getFriendLandsDetail(friendGid) {
             const plantCfg = getPlantById(plantId);
             const seedId = toNum(plantCfg && plantCfg.seed_id);
             const seedImage = seedId > 0 ? getSeedImageBySeedId(seedId) : '';
+            const plantSize = Math.max(1, toNum(plantCfg && plantCfg.size) || 1);
             const phaseName = PHASE_NAMES[phaseVal] || '';
             const maturePhase = Array.isArray(plant.phases)
                 ? plant.phases.find((p) => p && toNum(p.phase) === PlantPhase.MATURE)
@@ -587,6 +627,10 @@ async function getFriendLandsDetail(friendGid) {
                 needWater: toNum(plant.dry_num) > 0,
                 needWeed: (plant.weed_owners && plant.weed_owners.length > 0),
                 needBug: (plant.insect_owners && plant.insect_owners.length > 0),
+                occupiedByMaster,
+                masterLandId,
+                occupiedLandIds,
+                plantSize,
             });
         }
 

--- a/web/src/components/LandCard.vue
+++ b/web/src/components/LandCard.vue
@@ -75,6 +75,13 @@ function getLandTypeName(level: number) {
   }
   return typeMap[Number(level) || 0] || ''
 }
+
+function getPlantSizeText(land: any) {
+  const size = Number(land?.plantSize) || 1
+  if (size <= 1)
+    return ''
+  return `${size}x${size}`
+}
 </script>
 
 <template>
@@ -84,6 +91,12 @@ function getLandTypeName(level: number) {
   >
     <div class="absolute left-1 top-1 text-[10px] text-gray-400 font-mono">
       #{{ land.id }}
+    </div>
+    <div
+      v-if="land.plantSize > 1"
+      class="absolute right-1 top-1 rounded bg-pink-100 px-1 py-0.5 text-[10px] text-pink-700 dark:bg-pink-900/30 dark:text-pink-300"
+    >
+      合种 {{ getPlantSizeText(land) }}
     </div>
 
     <div class="mb-1 mt-4 h-10 w-10 flex items-center justify-center">

--- a/web/src/stores/friend.ts
+++ b/web/src/stores/friend.ts
@@ -13,23 +13,14 @@ export const useFriendStore = defineStore('friend', () => {
   const interactError = ref('')
 
   function buildPlantSummaryFromDetail(lands: any[], summary: any) {
-    const stealNumFromSummary = Array.isArray(summary?.stealable) ? summary.stealable.length : null
-    const dryNumFromSummary = Array.isArray(summary?.needWater) ? summary.needWater.length : null
-    const weedNumFromSummary = Array.isArray(summary?.needWeed) ? summary.needWeed.length : null
-    const insectNumFromSummary = Array.isArray(summary?.needBug) ? summary.needBug.length : null
+    let stealNum = 0
+    let dryNum = 0
+    let weedNum = 0
+    let insectNum = 0
 
-    let stealNum = stealNumFromSummary
-    let dryNum = dryNumFromSummary
-    let weedNum = weedNumFromSummary
-    let insectNum = insectNumFromSummary
-
-    if (stealNum === null || dryNum === null || weedNum === null || insectNum === null) {
-      stealNum = 0
-      dryNum = 0
-      weedNum = 0
-      insectNum = 0
-
-      for (const land of (Array.isArray(lands) ? lands : [])) {
+    const detailLands = Array.isArray(lands) ? lands : []
+    if (detailLands.length > 0) {
+      for (const land of detailLands) {
         if (!land || !land.unlocked)
           continue
         if (land.status === 'stealable')
@@ -41,6 +32,12 @@ export const useFriendStore = defineStore('friend', () => {
         if (land.needBug)
           insectNum++
       }
+    }
+    else {
+      stealNum = Array.isArray(summary?.stealable) ? summary.stealable.length : 0
+      dryNum = Array.isArray(summary?.needWater) ? summary.needWater.length : 0
+      weedNum = Array.isArray(summary?.needWeed) ? summary.needWeed.length : 0
+      insectNum = Array.isArray(summary?.needBug) ? summary.needBug.length : 0
     }
 
     return {


### PR DESCRIPTION
核心改动在 farm.js (line 166) 、farm.js (line 662) 、farm.js (line 815)：
后端现在会识别 master_land_id / slave_land_ids 这种多格关联地块，4 格合种时不再把另外 3 块误判为空地；土地详情会把主地块的作物状态映射到被占用的副地块上；自动种植也按作物 size 处理了，像爱心果这种 2x2 会按“1 粒种子占 4 块地”来购买和尝试播种，不再按 1 块地买 1 粒。

好友农场那条链路我也一起补了，在 friend.js (line 426) 和 friend.js (line 529)；前端卡片加了合种标识，在 LandCard.vue (line 79)；好友列表统计改成优先按展开后的土地详情计算，在 friend.ts (line 15)。

现在的效果应该是：

爱心果占用的 4 块地都会显示为已种植，不会再把 3 块当空地。
一键种植不会再把这些副地块继续拿去种别的。
如果策略选到这类 2x2 种子，买种子和播种会按合种尺寸处理。