### PR TITLE
feat(farm): 支持背包种子优先的第二优先策略

### DIFF
--- a/core/src/controllers/admin.js
+++ b/core/src/controllers/admin.js
@@ -593,6 +593,7 @@ function startAdminServer(dataProvider) {
             const strategy = store.getPlantingStrategy(id);
             const preferredSeed = store.getPreferredSeed(id);
             const bagSeedPriority = store.getBagSeedPriority(id);
+            const bagSeedFallbackStrategy = store.getBagSeedFallbackStrategy(id);
             const friendQuietHours = store.getFriendQuietHours(id);
             const automation = store.getAutomation(id);
             const ui = store.getUI();
@@ -605,7 +606,7 @@ function startAdminServer(dataProvider) {
             const runtimeClient = store.getRuntimeClientConfig
                 ? store.getRuntimeClientConfig()
                 : null;
-            res.json({ ok: true, data: { intervals, strategy, preferredSeed, bagSeedPriority, friendQuietHours, automation, ui, offlineReminder, qrLogin, runtimeClient } });
+            res.json({ ok: true, data: { intervals, strategy, preferredSeed, bagSeedPriority, bagSeedFallbackStrategy, friendQuietHours, automation, ui, offlineReminder, qrLogin, runtimeClient } });
         } catch (e) {
             res.status(500).json({ ok: false, error: e.message });
         }

--- a/core/src/models/store.js
+++ b/core/src/models/store.js
@@ -10,6 +10,7 @@ const { readTextFile, readJsonFile, writeJsonFileAtomic } = require('../services
 const STORE_FILE = getDataFile('store.json');
 const ACCOUNTS_FILE = getDataFile('accounts.json');
 const ALLOWED_PLANTING_STRATEGIES = ['preferred', 'level', 'max_exp', 'max_fert_exp', 'max_profit', 'max_fert_profit', 'bag_priority'];
+const ALLOWED_BAG_SEED_FALLBACK_STRATEGIES = ALLOWED_PLANTING_STRATEGIES.filter(strategy => strategy !== 'bag_priority');
 const PUSHOO_CHANNELS = new Set([
     'webhook', 'qmsg', 'serverchan', 'pushplus', 'pushplushxtrip',
     'dingtalk', 'wecom', 'bark', 'gocqhttp', 'onebot', 'atri',
@@ -83,6 +84,7 @@ const DEFAULT_ACCOUNT_CONFIG = {
     plantingStrategy: 'preferred',
     preferredSeedId: 0,
     bagSeedPriority: [],
+    bagSeedFallbackStrategy: 'level',
     intervals: {
         farm: 2,
         friend: 10,
@@ -340,6 +342,12 @@ function normalizeBagSeedPriority(input) {
     return normalized;
 }
 
+function normalizeBagSeedFallbackStrategy(input, fallback = DEFAULT_ACCOUNT_CONFIG.bagSeedFallbackStrategy) {
+    const strategy = String(input || '').trim();
+    if (ALLOWED_BAG_SEED_FALLBACK_STRATEGIES.includes(strategy)) return strategy;
+    return fallback;
+}
+
 function cloneAccountConfig(base = DEFAULT_ACCOUNT_CONFIG) {
     const srcAutomation = (base && base.automation && typeof base.automation === 'object')
         ? base.automation
@@ -369,6 +377,7 @@ function cloneAccountConfig(base = DEFAULT_ACCOUNT_CONFIG) {
             : DEFAULT_ACCOUNT_CONFIG.plantingStrategy,
         preferredSeedId: Math.max(0, Number.parseInt(base.preferredSeedId, 10) || 0),
         bagSeedPriority: normalizeBagSeedPriority(base.bagSeedPriority),
+        bagSeedFallbackStrategy: normalizeBagSeedFallbackStrategy(base.bagSeedFallbackStrategy),
     };
 }
 
@@ -409,6 +418,10 @@ function normalizeAccountConfig(input, fallback = accountFallbackConfig) {
 
     if (src.bagSeedPriority !== undefined) {
         cfg.bagSeedPriority = normalizeBagSeedPriority(src.bagSeedPriority);
+    }
+
+    if (src.bagSeedFallbackStrategy !== undefined) {
+        cfg.bagSeedFallbackStrategy = normalizeBagSeedFallbackStrategy(src.bagSeedFallbackStrategy, cfg.bagSeedFallbackStrategy);
     }
 
     if (src.intervals && typeof src.intervals === 'object') {
@@ -602,6 +615,8 @@ function getConfigSnapshot(accountId) {
         automation: { ...cfg.automation },
         plantingStrategy: cfg.plantingStrategy,
         preferredSeedId: cfg.preferredSeedId,
+        bagSeedPriority: [...(cfg.bagSeedPriority || [])],
+        bagSeedFallbackStrategy: cfg.bagSeedFallbackStrategy,
         intervals: { ...cfg.intervals },
         friendQuietHours: { ...cfg.friendQuietHours },
         friendBlacklist: [...(cfg.friendBlacklist || [])],
@@ -645,6 +660,10 @@ function applyConfigSnapshot(snapshot, options = {}) {
 
     if (cfg.bagSeedPriority !== undefined) {
         next.bagSeedPriority = normalizeBagSeedPriority(cfg.bagSeedPriority);
+    }
+
+    if (cfg.bagSeedFallbackStrategy !== undefined) {
+        next.bagSeedFallbackStrategy = normalizeBagSeedFallbackStrategy(cfg.bagSeedFallbackStrategy, next.bagSeedFallbackStrategy);
     }
 
     if (cfg.intervals && typeof cfg.intervals === 'object') {
@@ -698,6 +717,10 @@ function getPlantingStrategy(accountId) {
 
 function getBagSeedPriority(accountId) {
     return [...(getAccountConfigSnapshot(accountId).bagSeedPriority || [])];
+}
+
+function getBagSeedFallbackStrategy(accountId) {
+    return normalizeBagSeedFallbackStrategy(getAccountConfigSnapshot(accountId).bagSeedFallbackStrategy);
 }
 
 function setPlantingStrategy(accountId, strategy) {
@@ -874,6 +897,7 @@ module.exports = {
     getPreferredSeed,
     getPlantingStrategy,
     getBagSeedPriority,
+    getBagSeedFallbackStrategy,
     setPlantingStrategy,
     getIntervals,
     getFriendQuietHours,

--- a/core/src/runtime/data-provider.js
+++ b/core/src/runtime/data-provider.js
@@ -127,10 +127,12 @@ function createDataProvider(options) {
             const plantingStrategy = (body.plantingStrategy !== undefined) ? body.plantingStrategy : body.strategy;
             const preferredSeedId = (body.preferredSeedId !== undefined) ? body.preferredSeedId : body.seedId;
             const bagSeedPriority = body.bagSeedPriority;
+            const bagSeedFallbackStrategy = body.bagSeedFallbackStrategy;
             const snapshot = {
                 plantingStrategy,
                 preferredSeedId,
                 bagSeedPriority,
+                bagSeedFallbackStrategy,
                 intervals: body.intervals,
                 friendQuietHours: body.friendQuietHours,
             };
@@ -141,6 +143,7 @@ function createDataProvider(options) {
                 strategy: store.getPlantingStrategy(accountId),
                 preferredSeed: store.getPreferredSeed(accountId),
                 bagSeedPriority: store.getBagSeedPriority(accountId),
+                bagSeedFallbackStrategy: store.getBagSeedFallbackStrategy(accountId),
                 intervals: store.getIntervals(accountId),
                 friendQuietHours: store.getFriendQuietHours(accountId),
                 configRevision: rev,

--- a/core/src/runtime/runtime-state.js
+++ b/core/src/runtime/runtime-state.js
@@ -39,6 +39,8 @@ function createRuntimeState(options) {
             automation: store.getAutomation(accountId),
             plantingStrategy: store.getPlantingStrategy(accountId),
             preferredSeedId: store.getPreferredSeed(accountId),
+            bagSeedPriority: store.getBagSeedPriority(accountId),
+            bagSeedFallbackStrategy: store.getBagSeedFallbackStrategy(accountId),
             intervals: store.getIntervals(accountId),
             friendQuietHours: store.getFriendQuietHours(accountId),
             friendBlacklist: store.getFriendBlacklist(accountId),

--- a/core/src/services/config-validator.js
+++ b/core/src/services/config-validator.js
@@ -126,10 +126,16 @@ const ACCOUNT_CONFIG_SCHEMA = {
         intervals: INTERVALS_SCHEMA,
         plantingStrategy: {
             type: 'string',
-            oneOf: ['preferred', 'level', 'max_exp', 'max_fert_exp', 'max_profit', 'max_fert_profit'],
+            oneOf: ['preferred', 'level', 'max_exp', 'max_fert_exp', 'max_profit', 'max_fert_profit', 'bag_priority'],
             default: 'preferred',
         },
         preferredSeedId: { type: 'number', min: 0, default: 0 },
+        bagSeedPriority: { type: 'array', items: { type: 'number', min: 1 }, default: [] },
+        bagSeedFallbackStrategy: {
+            type: 'string',
+            oneOf: ['preferred', 'level', 'max_exp', 'max_fert_exp', 'max_profit', 'max_fert_profit'],
+            default: 'level',
+        },
         friendQuietHours: QUIET_HOURS_SCHEMA,
         friendBlacklist: { type: 'array', items: { type: 'number' }, default: [] },
     },

--- a/core/src/services/farm.js
+++ b/core/src/services/farm.js
@@ -5,7 +5,7 @@
 const protobuf = require('protobufjs');
 const { CONFIG, PlantPhase, PHASE_NAMES } = require('../config/config');
 const { getPlantNameBySeedId, getPlantName, getPlantExp, formatGrowTime, getPlantGrowTime, getAllSeeds, getPlantById, getPlantBySeedId, getSeedImageBySeedId } = require('../config/gameConfig');
-const { isAutomationOn, getPreferredSeed, getAutomation, getPlantingStrategy, getBagSeedPriority, setPlantingStrategy } = require('../models/store');
+const { isAutomationOn, getPreferredSeed, getAutomation, getPlantingStrategy, getBagSeedPriority, getBagSeedFallbackStrategy } = require('../models/store');
 const { sendMsgAsync, getUserState, networkEvents, getWsErrorState } = require('../utils/network');
 const { types } = require('../utils/proto');
 const { toLong, toNum, getServerTimeSec, toTimeSec, log, logWarn, sleep } = require('../utils/utils');
@@ -13,6 +13,7 @@ const { getPlantRankings } = require('./analytics');
 const { createScheduler } = require('./scheduler');
 const { recordOperation } = require('./stats');
 const { getFarmOptimizer } = require('./rate-limiter');
+const { getBagSeeds } = require('./warehouse');
 
 // ============ 内部状态 ============
 let isCheckingFarm = false;
@@ -82,6 +83,22 @@ async function insecticide(landIds) {
 const NORMAL_FERTILIZER_ID = 1011;
 // 有机肥料 ID
 const ORGANIC_FERTILIZER_ID = 1012;
+const SHOP_PLANTING_STRATEGY_SET = new Set(['preferred', 'level', 'max_exp', 'max_fert_exp', 'max_profit', 'max_fert_profit']);
+const ANALYTICS_SORT_BY_MAP = {
+    max_exp: 'exp',
+    max_fert_exp: 'fert',
+    max_profit: 'profit',
+    max_fert_profit: 'fert_profit',
+};
+const PLANTING_STRATEGY_LABELS = {
+    preferred: '优先种植种子',
+    level: '最高等级作物',
+    max_exp: '最大经验/时',
+    max_fert_exp: '最大普通肥经验/时',
+    max_profit: '最大净利润/时',
+    max_fert_profit: '最大普通肥净利润/时',
+    bag_priority: '背包种子优先',
+};
 
 /**
  * 施肥 - 必须逐块进行，服务器不支持批量
@@ -505,7 +522,7 @@ async function plantSeeds(seedId, landIds, options = {}) {
     };
 }
 
-async function findBestSeed() {
+async function findBestSeed(strategyOverride = '') {
     const SEED_SHOP_ID = 2;
     const shopReply = await getShopInfo(SEED_SHOP_ID);
     if (!shopReply.goods_list || shopReply.goods_list.length === 0) {
@@ -551,14 +568,8 @@ async function findBestSeed() {
     }
 
     // 按策略排序
-    const strategy = getPlantingStrategy();
-    const analyticsSortByMap = {
-        max_exp: 'exp',
-        max_fert_exp: 'fert',
-        max_profit: 'profit',
-        max_fert_profit: 'fert_profit',
-    };
-    const analyticsSortBy = analyticsSortByMap[strategy];
+    const strategy = normalizeShopPlantingStrategy(strategyOverride);
+    const analyticsSortBy = ANALYTICS_SORT_BY_MAP[strategy];
     if (analyticsSortBy) {
         try {
             const rankings = getPlantRankings(analyticsSortBy);
@@ -845,149 +856,212 @@ async function autoPlantEmptyLands(deadLandIds, emptyLandIds) {
         module: 'farm', event: 'plant_strategy', strategy
     });
 
-    // 2. 背包种子优先模式
+    let totalPlanted = 0;
+    let occupiedCount = 0;
+    const plantedLandIds = [];
+
     if (strategy === 'bag_priority') {
-        const planted = await plantFromBagSeeds(landsToPlant);
-        if (planted) return;
-        // 背包种子用完或空地不足，继续检查是否需要切换策略
+        let bagResult;
+        try {
+            bagResult = await plantFromBagSeeds(landsToPlant);
+        } catch (e) {
+            logWarn('种植', `读取背包种子失败，本轮跳过第二优先策略以避免误购: ${e.message}`, {
+                module: 'farm',
+                event: 'plant_seed',
+                result: 'bag_load_error',
+            });
+            return {
+                totalPlanted: 0,
+                occupiedCount: 0,
+                plantedLandIds: [],
+            };
+        }
+
+        totalPlanted += bagResult.totalPlanted;
+        occupiedCount += bagResult.occupiedCount;
+        plantedLandIds.push(...bagResult.plantedLandIds);
+
+        if (bagResult.fallbackAllowed && bagResult.remainingLandIds.length > 0) {
+            const fallbackStrategy = normalizeShopPlantingStrategy(getBagSeedFallbackStrategy());
+            log('种植', `开始按第二优先策略“${getPlantingStrategyLabel(fallbackStrategy)}”补种剩余空地`, {
+                module: 'farm',
+                event: 'plant_seed',
+                result: 'fallback_start',
+                strategy: fallbackStrategy,
+                remainingCount: bagResult.remainingLandIds.length,
+            });
+            const shopResult = await plantFromShop(bagResult.remainingLandIds, state, fallbackStrategy);
+            totalPlanted += shopResult.totalPlanted;
+            occupiedCount += shopResult.occupiedCount;
+            plantedLandIds.push(...shopResult.plantedLandIds);
+        }
+    } else {
+        const shopResult = await plantFromShop(landsToPlant, state);
+        totalPlanted += shopResult.totalPlanted;
+        occupiedCount += shopResult.occupiedCount;
+        plantedLandIds.push(...shopResult.plantedLandIds);
     }
 
-    // 3. 非背包优先模式，或背包种子已用完，从商店购买
-    await plantFromShop(landsToPlant, state);
+    if (plantedLandIds.length > 0) {
+        await runFertilizerByConfig(uniqPositiveNumbers(plantedLandIds));
+    }
+
+    return {
+        totalPlanted,
+        occupiedCount,
+        plantedLandIds: uniqPositiveNumbers(plantedLandIds),
+    };
 }
 
 /**
  * 从背包种子种植
- * @returns {boolean} true=已种植或等待中，false=需要从商店购买
  */
 async function plantFromBagSeeds(landsToPlant) {
-    const { getBagSeeds } = require('./warehouse');
+    const targetLandIds = uniqPositiveNumbers(landsToPlant);
+    if (targetLandIds.length === 0) {
+        return {
+            remainingLandIds: [],
+            fallbackAllowed: false,
+            plantedLandIds: [],
+            totalPlanted: 0,
+            occupiedCount: 0,
+        };
+    }
 
-    let bagSeeds;
-    try {
-        bagSeeds = await getBagSeeds();
-        log('背包', `获取到 ${bagSeeds.length} 种种子: ${bagSeeds.map(s => `${s.name}x${s.count}`).join(', ') || '无'}`, {
-            module: 'farm', event: 'bag_seeds_fetch', count: bagSeeds.length
+    const bagSeeds = await getBagSeeds();
+    const allBagSeeds = Array.isArray(bagSeeds) ? bagSeeds : [];
+    const usableSeeds = sortBagSeedsForPlanting(
+        allBagSeeds.filter(seed => Number(seed && seed.count) > 0 && Number(seed && seed.plantSize) === 1),
+        getBagSeedPriority(),
+    );
+
+    if (usableSeeds.length === 0) {
+        const hasAnyBagSeed = allBagSeeds.some(seed => Number(seed && seed.count) > 0);
+        log('种植', hasAnyBagSeed
+            ? '背包中没有可用的 1x1 种子，准备按第二优先策略补种'
+            : '背包种子已用完，准备按第二优先策略补种', {
+            module: 'farm',
+            event: 'plant_seed',
+            result: 'fallback_ready',
+            strategy: 'bag_priority',
         });
-    } catch (e) {
-        logWarn('背包', `获取背包种子失败: ${e.message}`);
-        return false;
+        return {
+            remainingLandIds: targetLandIds,
+            fallbackAllowed: true,
+            plantedLandIds: [],
+            totalPlanted: 0,
+            occupiedCount: 0,
+        };
     }
 
-    if (!bagSeeds || bagSeeds.length === 0) {
-        log('种植', '背包无种子，自动切换为最高等级策略', {
-            module: 'farm', event: 'bag_empty', result: 'switch_strategy'
-        });
-        setPlantingStrategy(undefined, 'level');
-        return false;
-    }
-
-    // 按用户设置的优先级排序
-    const priority = getBagSeedPriority();
-    log('背包', `用户优先级设置: ${priority.length > 0 ? priority.join(',') : '无(按等级排序)'}`, {
-        module: 'farm', event: 'bag_priority', priority
-    });
-    const sortedSeeds = sortBagSeedsByPriority(bagSeeds, priority);
-
-    // 按用户优先级遍历种子，找到第一个可用的 1x1 种子
-    let availableSeed = null;
-
-    for (const seed of sortedSeeds) {
-        if (seed.count <= 0) continue;
-        const size = seed.plantSize || 1;
-
-        // 跳过大尺寸种子 (2x2 等)
-        if (size > 1) {
-            log('种植', `${seed.name} 是 ${size}x${size} 种子，暂不支持，跳过`, {
-                module: 'farm', event: 'bag_seed_skip_large', seedId: seed.seedId, size
-            });
-            continue;
-        }
-
-        // 1x1 种子直接使用
-        if (landsToPlant.length > 0) {
-            availableSeed = seed;
-            break;
-        }
-    }
-
-    if (!availableSeed) {
-        // 检查是否有 1x1 种子
-        const has1x1Seeds = sortedSeeds.some(s => s.count > 0 && (s.plantSize || 1) === 1);
-        if (!has1x1Seeds) {
-            log('种植', '背包无可用 1x1 种子，自动切换为最高等级策略', {
-                module: 'farm', event: 'bag_seeds_exhausted', result: 'switch_strategy'
-            });
-            setPlantingStrategy(undefined, 'level');
-            return false;
-        }
-        return true;
-    }
-
-    // 计算能种多少
-    const needCount = Math.min(landsToPlant.length, availableSeed.count);
-    if (needCount <= 0) {
-        return true;
-    }
-
-    // 种植背包种子
-    let plantedLands = [];
+    let remainingLandIds = [...targetLandIds];
+    let fallbackAllowed = true;
     let totalPlanted = 0;
+    let occupiedCount = 0;
+    const plantedLandIds = [];
+    const usedSeedLogs = [];
 
-    const landsToUse = landsToPlant.slice(0, needCount);
-    try {
-        const { planted, plantedLandIds } = await plantSeeds(
-            availableSeed.seedId,
-            landsToUse,
-            { maxPlantCount: needCount }
-        );
-        totalPlanted = planted;
-        plantedLands = plantedLandIds;
-    } catch (e) {
-        logWarn('种植', `背包种子种植失败: ${e.message}`);
-        return false;
+    for (const seed of usableSeeds) {
+        if (remainingLandIds.length === 0) break;
+
+        const maxPlantCount = Math.min(Number(seed.count || 0), remainingLandIds.length);
+        if (maxPlantCount <= 0) continue;
+
+        const result = await plantSeeds(seed.seedId, remainingLandIds, { maxPlantCount });
+        const currentOccupied = uniqPositiveNumbers(result.occupiedLandIds);
+        const currentPlantedLandIds = uniqPositiveNumbers(result.plantedLandIds);
+        if (result.planted > 0) {
+            totalPlanted += result.planted;
+            occupiedCount += currentOccupied.length > 0 ? currentOccupied.length : result.planted;
+            plantedLandIds.push(...currentPlantedLandIds);
+            remainingLandIds = excludeOccupiedLandIds(remainingLandIds, currentOccupied);
+            usedSeedLogs.push(`${seed.name}x${result.planted}`);
+        }
+
+        if (result.planted < maxPlantCount && remainingLandIds.length > 0) {
+            fallbackAllowed = false;
+            logWarn('种植', `背包种子 ${seed.name} 实际种植 ${result.planted}/${maxPlantCount}，为避免误购商店种子，本轮不执行第二优先策略`, {
+                module: 'farm',
+                event: 'plant_seed',
+                result: 'partial_bag_failure',
+                seedId: seed.seedId,
+                requested: maxPlantCount,
+                planted: result.planted,
+            });
+        }
     }
 
-    const isEvent = availableSeed.requiredLevel >= 200;
-    const seedLabel = isEvent ? `[活动] ${availableSeed.name}` : availableSeed.name;
-    log('种植', `使用背包种子 ${seedLabel} 种植 ${totalPlanted} 块地`, {
-        module: 'farm',
-        event: 'bag_seed_plant',
-        result: 'ok',
-        seedId: availableSeed.seedId,
-        count: totalPlanted,
-        isEvent,
-    });
-
-    if (totalPlanted > 0) {
-        recordOperation('plant', totalPlanted);
+    if (usedSeedLogs.length > 0) {
+        log('种植', `已按背包优先策略种植: ${usedSeedLogs.join('，')}`, {
+            module: 'farm',
+            event: 'plant_seed',
+            result: 'ok',
+            strategy: 'bag_priority',
+            count: totalPlanted,
+        });
     }
 
-    // 施肥
-    await runFertilizerByConfig(plantedLands);
-    return true;
+    if (remainingLandIds.length > 0 && fallbackAllowed) {
+        log('种植', `背包种子不足，剩余 ${remainingLandIds.length} 块空地待第二优先策略补种`, {
+            module: 'farm',
+            event: 'plant_seed',
+            result: 'fallback_ready',
+            strategy: 'bag_priority',
+            remainingCount: remainingLandIds.length,
+        });
+    }
+
+    return {
+        remainingLandIds,
+        fallbackAllowed,
+        plantedLandIds: uniqPositiveNumbers(plantedLandIds),
+        totalPlanted,
+        occupiedCount,
+    };
 }
 
-/**
- * 按优先级排序背包种子
- */
-function sortBagSeedsByPriority(bagSeeds, priority) {
-    if (!priority || priority.length === 0) {
-        // 无优先级设置，按等级降序
-        return [...bagSeeds].sort((a, b) => b.requiredLevel - a.requiredLevel);
-    }
+function normalizeShopPlantingStrategy(strategy) {
+    const raw = String(strategy || '').trim();
+    if (SHOP_PLANTING_STRATEGY_SET.has(raw)) return raw;
 
-    const priorityMap = new Map();
-    priority.forEach((seedId, index) => {
-        priorityMap.set(seedId, index);
+    const current = String(getPlantingStrategy() || '').trim();
+    if (SHOP_PLANTING_STRATEGY_SET.has(current)) return current;
+    if (current === 'bag_priority') {
+        const fallback = String(getBagSeedFallbackStrategy() || '').trim();
+        if (SHOP_PLANTING_STRATEGY_SET.has(fallback)) return fallback;
+    }
+    return 'level';
+}
+
+function getPlantingStrategyLabel(strategy) {
+    return PLANTING_STRATEGY_LABELS[String(strategy || '').trim()] || String(strategy || '默认策略');
+}
+
+function uniqPositiveNumbers(values) {
+    return [...new Set((Array.isArray(values) ? values : []).map(v => toNum(v)).filter(Boolean))];
+}
+
+function excludeOccupiedLandIds(landIds, occupiedLandIds) {
+    const occupied = new Set(uniqPositiveNumbers(occupiedLandIds));
+    return uniqPositiveNumbers(landIds).filter(id => !occupied.has(id));
+}
+
+function sortBagSeedsForPlanting(bagSeeds, priorityList) {
+    const indexMap = new Map();
+    uniqPositiveNumbers(priorityList).forEach((seedId, index) => {
+        indexMap.set(seedId, index);
     });
 
-    return [...bagSeeds].sort((a, b) => {
-        const pa = priorityMap.has(a.seedId) ? priorityMap.get(a.seedId) : Number.MAX_SAFE_INTEGER;
-        const pb = priorityMap.has(b.seedId) ? priorityMap.get(b.seedId) : Number.MAX_SAFE_INTEGER;
-        if (pa !== pb) return pa - pb;
-        // 优先级相同时按等级降序
-        return b.requiredLevel - a.requiredLevel;
+    return [...(Array.isArray(bagSeeds) ? bagSeeds : [])].sort((a, b) => {
+        const aIndex = indexMap.has(a.seedId) ? indexMap.get(a.seedId) : Number.MAX_SAFE_INTEGER;
+        const bIndex = indexMap.has(b.seedId) ? indexMap.get(b.seedId) : Number.MAX_SAFE_INTEGER;
+        if (aIndex !== bIndex) return aIndex - bIndex;
+
+        const aLevel = Number(a.requiredLevel || 0);
+        const bLevel = Number(b.requiredLevel || 0);
+        if (aLevel !== bLevel) return bLevel - aLevel;
+
+        return Number(a.seedId || 0) - Number(b.seedId || 0);
     });
 }
 
@@ -1007,49 +1081,108 @@ function sortBagSeedsByPriority(bagSeeds, priority) {
 /**
  * 从商店购买种子并种植
  */
-async function plantFromShop(landsToPlant, state) {
+async function plantFromShop(landsToPlant, state, strategyOverride = '') {
+    const targetLandIds = uniqPositiveNumbers(landsToPlant);
+    if (targetLandIds.length === 0) {
+        return {
+            totalPlanted: 0,
+            occupiedCount: 0,
+            plantedLandIds: [],
+            occupiedLandIds: [],
+            remainingLandIds: [],
+        };
+    }
+
+    const strategy = normalizeShopPlantingStrategy(strategyOverride);
+
     let bestSeed;
     try {
-        bestSeed = await findBestSeed();
+        bestSeed = await findBestSeed(strategy);
     } catch (e) {
         logWarn('商店', `查询失败: ${e.message}`);
-        return;
+        return {
+            totalPlanted: 0,
+            occupiedCount: 0,
+            plantedLandIds: [],
+            occupiedLandIds: [],
+            remainingLandIds: targetLandIds,
+        };
     }
-    if (!bestSeed) return;
+    if (!bestSeed) {
+        return {
+            totalPlanted: 0,
+            occupiedCount: 0,
+            plantedLandIds: [],
+            occupiedLandIds: [],
+            remainingLandIds: targetLandIds,
+        };
+    }
 
     const seedName = getPlantNameBySeedId(bestSeed.seedId);
-    const growTime = getPlantGrowTime(1020000 + (bestSeed.seedId - 20000));
+    const plantConfig = getPlantBySeedId(bestSeed.seedId);
+    const growTime = getPlantGrowTime(toNum(plantConfig && plantConfig.id));
     const growTimeStr = growTime > 0 ? ` 生长${formatGrowTime(growTime)}` : '';
     const plantSize = getPlantSizeBySeedId(bestSeed.seedId);
     const landFootprint = plantSize * plantSize;
-    log('商店', `最佳种子: ${seedName} (${bestSeed.seedId}) 价格=${bestSeed.price}金币${growTimeStr}`, {
-        module: 'warehouse', event: 'seed_pick', seedId: bestSeed.seedId, price: bestSeed.price
+    const unitPrice = Math.max(0, Number(bestSeed.price) || 0);
+    log('商店', `最佳种子: ${seedName} (${bestSeed.seedId}) 价格=${bestSeed.price}金币${growTimeStr} [${getPlantingStrategyLabel(strategy)}]`, {
+        module: 'warehouse',
+        event: 'seed_pick',
+        seedId: bestSeed.seedId,
+        price: bestSeed.price,
+        strategy,
     });
 
-    let needCount = landsToPlant.length;
+    let needCount = targetLandIds.length;
     if (landFootprint > 1) {
-        needCount = Math.floor(landsToPlant.length / landFootprint);
+        needCount = Math.floor(targetLandIds.length / landFootprint);
         if (needCount <= 0) {
-            log('种植', `${seedName} 需要至少 ${landFootprint} 块空地才能合并种植，当前仅 ${landsToPlant.length} 块可用，已跳过`, {
+            log('种植', `${seedName} 需要至少 ${landFootprint} 块空地才能合并种植，当前仅 ${targetLandIds.length} 块可用，已跳过`, {
                 module: 'farm',
                 event: 'plant_seed',
                 result: 'skip',
                 seedId: bestSeed.seedId,
                 landFootprint,
-                emptyCount: landsToPlant.length,
+                emptyCount: targetLandIds.length,
+                strategy,
             });
-            return;
+            return {
+                totalPlanted: 0,
+                occupiedCount: 0,
+                plantedLandIds: [],
+                occupiedLandIds: [],
+                remainingLandIds: targetLandIds,
+            };
         }
     }
-    const totalCost = bestSeed.price * needCount;
-    if (totalCost > state.gold) {
+    const totalCost = unitPrice * needCount;
+    if (unitPrice > 0 && totalCost > state.gold) {
         logWarn('商店', `金币不足! 需要 ${totalCost} 金币, 当前 ${state.gold} 金币`, {
-            module: 'farm', event: 'seed_buy_skip', result: 'insufficient_gold', need: totalCost, current: state.gold
+            module: 'farm',
+            event: 'seed_buy_skip',
+            result: 'insufficient_gold',
+            need: totalCost,
+            current: state.gold,
+            strategy,
         });
-        const canBuy = Math.floor(state.gold / bestSeed.price);
-        if (canBuy <= 0) return;
+        const canBuy = Math.floor(state.gold / unitPrice);
+        if (canBuy <= 0) {
+            return {
+                totalPlanted: 0,
+                occupiedCount: 0,
+                plantedLandIds: [],
+                occupiedLandIds: [],
+                remainingLandIds: targetLandIds,
+            };
+        }
         needCount = canBuy;
-        log('商店', plantSize > 1 ? `金币有限，只尝试种植 ${canBuy} 组 ${plantSize}x${plantSize} 作物` : `金币有限，只种 ${canBuy} 块地`);
+        log('商店', plantSize > 1 ? `金币有限，只尝试种植 ${canBuy} 组 ${plantSize}x${plantSize} 作物` : `金币有限，只种 ${canBuy} 块地`, {
+            module: 'warehouse',
+            event: 'seed_buy',
+            result: 'limited_by_gold',
+            strategy,
+            count: canBuy,
+        });
     }
 
     let actualSeedId = bestSeed.seedId;
@@ -1073,35 +1206,60 @@ async function plantFromShop(landsToPlant, state) {
             seedId: actualSeedId,
             count: needCount,
             cost: bestSeed.price * needCount,
+            strategy,
         });
     } catch (e) {
         logWarn('购买', e.message);
-        return;
+        return {
+            totalPlanted: 0,
+            occupiedCount: 0,
+            plantedLandIds: [],
+            occupiedLandIds: [],
+            remainingLandIds: targetLandIds,
+        };
     }
 
-    let plantedLands = [];
+    let plantedLandIds = [];
+    let occupiedLandIds = [];
+    let planted = 0;
     try {
-        const { planted, plantedLandIds, occupiedLandIds } = await plantSeeds(actualSeedId, landsToPlant, { maxPlantCount: needCount });
+        const plantResult = await plantSeeds(actualSeedId, targetLandIds, { maxPlantCount: needCount });
+        planted = plantResult.planted;
+        plantedLandIds = uniqPositiveNumbers(plantResult.plantedLandIds);
+        occupiedLandIds = uniqPositiveNumbers(plantResult.occupiedLandIds);
         const occupiedCount = occupiedLandIds.length > 0 ? occupiedLandIds.length : planted;
         log('种植', plantSize > 1
             ? `已种植 ${planted} 组 ${plantSize}x${plantSize} 作物，占用 ${occupiedCount} 块地 (${occupiedLandIds.join(',')})`
-            : `已在 ${planted} 块地种植 (${landsToPlant.slice(0, planted).join(',')})`, {
+            : `已在 ${planted} 块地种植 (${targetLandIds.slice(0, planted).join(',')})`, {
             module: 'farm',
             event: 'plant_seed',
             result: 'ok',
             seedId: actualSeedId,
             count: planted,
             occupiedCount,
+            strategy,
         });
         if (planted > 0) {
-            plantedLands = plantedLandIds;
             recordOperation('plant', planted);
         }
     } catch (e) {
         logWarn('种植', e.message);
+        return {
+            totalPlanted: 0,
+            occupiedCount: 0,
+            plantedLandIds: [],
+            occupiedLandIds: [],
+            remainingLandIds: targetLandIds,
+        };
     }
 
-    await runFertilizerByConfig(plantedLands);
+    return {
+        totalPlanted: planted,
+        occupiedCount: occupiedLandIds.length > 0 ? occupiedLandIds.length : planted,
+        plantedLandIds,
+        occupiedLandIds,
+        remainingLandIds: excludeOccupiedLandIds(targetLandIds, occupiedLandIds),
+    };
 }
 
 function getCurrentPhase(phases, debug, landLabel) {

--- a/web/src/stores/setting.ts
+++ b/web/src/stores/setting.ts
@@ -85,6 +85,7 @@ export interface SettingsState {
   plantingStrategy: string
   preferredSeedId: number
   bagSeedPriority: number[]
+  bagSeedFallbackStrategy: string
   intervals: IntervalsConfig
   friendQuietHours: FriendQuietHoursConfig
   automation: AutomationConfig
@@ -99,6 +100,7 @@ export const useSettingStore = defineStore('setting', () => {
     plantingStrategy: 'preferred',
     preferredSeedId: 0,
     bagSeedPriority: [],
+    bagSeedFallbackStrategy: 'level',
     intervals: {},
     friendQuietHours: { enabled: false, start: '23:00', end: '07:00' },
     automation: {},
@@ -145,6 +147,7 @@ export const useSettingStore = defineStore('setting', () => {
         settings.value.plantingStrategy = d.strategy || 'preferred'
         settings.value.preferredSeedId = d.preferredSeed || 0
         settings.value.bagSeedPriority = Array.isArray(d.bagSeedPriority) ? d.bagSeedPriority : []
+        settings.value.bagSeedFallbackStrategy = d.bagSeedFallbackStrategy || 'level'
         settings.value.intervals = d.intervals || {}
         settings.value.friendQuietHours = d.friendQuietHours || { enabled: false, start: '23:00', end: '07:00' }
         settings.value.automation = d.automation || {}
@@ -193,6 +196,7 @@ export const useSettingStore = defineStore('setting', () => {
         plantingStrategy: newSettings.plantingStrategy,
         preferredSeedId: newSettings.preferredSeedId,
         bagSeedPriority: newSettings.bagSeedPriority,
+        bagSeedFallbackStrategy: newSettings.bagSeedFallbackStrategy,
         intervals: newSettings.intervals,
         friendQuietHours: newSettings.friendQuietHours,
       }

--- a/web/src/views/Settings.vue
+++ b/web/src/views/Settings.vue
@@ -33,7 +33,7 @@ const token = computed(() => {
   return localStorage.getItem('admin_token') || '未登录'
 })
 
-const copyToClipboard = (text: string) => {
+function copyToClipboard(text: string) {
   navigator.clipboard.writeText(text).then(() => {
     toast.success('复制成功')
   }).catch(() => {
@@ -63,6 +63,9 @@ const currentAccountName = computed(() => {
   const acc = accounts.value.find((a: any) => a.id === currentAccountId.value)
   return acc ? (acc.name || acc.nick || acc.id) : null
 })
+const BAG_PRIORITY_STRATEGY = 'bag_priority'
+const DEFAULT_BAG_SEED_FALLBACK_STRATEGY = 'level'
+const BAG_FALLBACK_STRATEGY_VALUES = new Set(['preferred', 'level', 'max_exp', 'max_fert_exp', 'max_profit', 'max_fert_profit'])
 const allFertilizerLandTypes = ['gold', 'black', 'red', 'normal']
 
 const fertilizerLandTypeOptions = [
@@ -104,6 +107,7 @@ const localSettings = ref({
   plantingStrategy: 'preferred',
   preferredSeedId: 0,
   bagSeedPriority: [] as number[],
+  bagSeedFallbackStrategy: DEFAULT_BAG_SEED_FALLBACK_STRATEGY,
   intervals: { farmMin: 2, farmMax: 2, friendMin: 10, friendMax: 10 },
   friendQuietHours: { enabled: false, start: '23:00', end: '07:00' },
   automation: {
@@ -138,6 +142,7 @@ const localSettings = ref({
 
 const friendDisabled = computed(() => !localSettings.value.automation.friend)
 const farmDisabled = computed(() => !localSettings.value.automation.farm_manage)
+const isBagPriorityStrategy = computed(() => localSettings.value.plantingStrategy === BAG_PRIORITY_STRATEGY)
 
 interface StealCropOption {
   plantId: number
@@ -408,6 +413,7 @@ function syncLocalSettings() {
       plantingStrategy: settings.value.plantingStrategy,
       preferredSeedId: settings.value.preferredSeedId,
       bagSeedPriority: settings.value.bagSeedPriority || [],
+      bagSeedFallbackStrategy: settings.value.bagSeedFallbackStrategy || DEFAULT_BAG_SEED_FALLBACK_STRATEGY,
       intervals: settings.value.intervals,
       friendQuietHours: settings.value.friendQuietHours,
       automation: settings.value.automation,
@@ -482,6 +488,12 @@ function syncLocalSettings() {
 
     localSettings.value.automation.fertilizer_land_types = normalizeFertilizerLandTypes(localSettings.value.automation.fertilizer_land_types)
     localSettings.value.automation.friend_steal_blacklist = normalizeStealPlantBlacklist(localSettings.value.automation.friend_steal_blacklist)
+    if (
+      localSettings.value.bagSeedFallbackStrategy === BAG_PRIORITY_STRATEGY
+      || !BAG_FALLBACK_STRATEGY_VALUES.has(localSettings.value.bagSeedFallbackStrategy)
+    ) {
+      localSettings.value.bagSeedFallbackStrategy = DEFAULT_BAG_SEED_FALLBACK_STRATEGY
+    }
 
     // Sync offline settings (global)
     if (settings.value.offlineReminder) {
@@ -529,7 +541,7 @@ const fertilizerOptions = [
 ]
 
 const plantingStrategyOptions = [
-  { label: '优先背包种子', value: 'bag_priority' },
+  { label: '优先背包种子', value: BAG_PRIORITY_STRATEGY },
   { label: '优先种植种子', value: 'preferred' },
   { label: '最高等级作物', value: 'level' },
   { label: '最大经验/时', value: 'max_exp' },
@@ -537,6 +549,10 @@ const plantingStrategyOptions = [
   { label: '最大净利润/时', value: 'max_profit' },
   { label: '最大普通肥净利润/时', value: 'max_fert_profit' },
 ]
+
+const bagSeedFallbackStrategyOptions = computed(() =>
+  plantingStrategyOptions.filter(option => option.value !== BAG_PRIORITY_STRATEGY),
+)
 
 const channelOptions = [
   { label: 'Webhook(自定义接口)', value: 'webhook' },
@@ -628,7 +644,8 @@ const bagSeeds = ref<BagSeedItem[]>([])
 const bagSeedsLoading = ref(false)
 
 async function fetchBagSeeds() {
-  if (!currentAccountId.value) return
+  if (!currentAccountId.value)
+    return
   bagSeedsLoading.value = true
   try {
     const { data } = await api.get('/api/bag/seeds', {
@@ -656,13 +673,15 @@ const sortedBagSeeds = computed(() => {
   return [...bagSeeds.value].sort((a, b) => {
     const pa = priorityMap.has(a.seedId) ? priorityMap.get(a.seedId)! : Number.MAX_SAFE_INTEGER
     const pb = priorityMap.has(b.seedId) ? priorityMap.get(b.seedId)! : Number.MAX_SAFE_INTEGER
-    if (pa !== pb) return pa - pb
+    if (pa !== pb)
+      return pa - pb
     return b.requiredLevel - a.requiredLevel
   })
 })
 
 function moveSeedUp(index: number) {
-  if (index <= 0) return
+  if (index <= 0)
+    return
   const seeds = sortedBagSeeds.value
   const newPriority: number[] = seeds.map(s => s.seedId)
   const a = newPriority[index]!
@@ -674,7 +693,8 @@ function moveSeedUp(index: number) {
 
 function moveSeedDown(index: number) {
   const seeds = sortedBagSeeds.value
-  if (index >= seeds.length - 1) return
+  if (index >= seeds.length - 1)
+    return
   const newPriority: number[] = seeds.map(s => s.seedId)
   const a = newPriority[index]!
   const b = newPriority[index + 1]!
@@ -722,10 +742,19 @@ function onDragEnd() {
 }
 
 watch(() => localSettings.value.plantingStrategy, (newVal) => {
-  if (newVal === 'bag_priority') {
+  if (newVal === BAG_PRIORITY_STRATEGY) {
     fetchBagSeeds()
   }
 }, { immediate: true })
+
+watch(() => localSettings.value.bagSeedFallbackStrategy, (strategy) => {
+  if (
+    strategy === BAG_PRIORITY_STRATEGY
+    || !bagSeedFallbackStrategyOptions.value.some(option => option.value === strategy)
+  ) {
+    localSettings.value.bagSeedFallbackStrategy = DEFAULT_BAG_SEED_FALLBACK_STRATEGY
+  }
+})
 
 const analyticsSortByMap: Record<string, string> = {
   max_exp: 'exp',
@@ -738,7 +767,7 @@ const strategyPreviewLabel = ref<string | null>(null)
 
 watchEffect(async () => {
   const strategy = localSettings.value.plantingStrategy
-  if (strategy === 'preferred' || strategy === 'bag_priority') {
+  if (strategy === 'preferred' || strategy === BAG_PRIORITY_STRATEGY) {
     strategyPreviewLabel.value = null
     return
   }
@@ -783,6 +812,12 @@ async function saveAccountSettings() {
 
   localSettings.value.automation.fertilizer_land_types = normalizeFertilizerLandTypes(localSettings.value.automation.fertilizer_land_types)
   localSettings.value.automation.friend_steal_blacklist = normalizeStealPlantBlacklist(localSettings.value.automation.friend_steal_blacklist)
+  if (
+    localSettings.value.bagSeedFallbackStrategy === BAG_PRIORITY_STRATEGY
+    || !bagSeedFallbackStrategyOptions.value.some(option => option.value === localSettings.value.bagSeedFallbackStrategy)
+  ) {
+    localSettings.value.bagSeedFallbackStrategy = DEFAULT_BAG_SEED_FALLBACK_STRATEGY
+  }
 
   saving.value = true
   try {
@@ -910,8 +945,6 @@ async function handleTestOffline() {
     </div>
 
     <div v-else class="grid grid-cols-1 mt-12 gap-4 text-sm lg:grid-cols-2">
-
-
       <!-- Card 1: Strategy & Automation -->
       <div v-if="currentAccountId" class="card h-full flex flex-col rounded-lg bg-white shadow dark:bg-gray-800">
         <!-- Strategy Header -->
@@ -939,8 +972,14 @@ async function handleTestOffline() {
               label="优先种植种子"
               :options="preferredSeedOptions"
             />
+            <BaseSelect
+              v-else-if="isBagPriorityStrategy"
+              v-model="localSettings.bagSeedFallbackStrategy"
+              label="第二优先策略"
+              :options="bagSeedFallbackStrategyOptions"
+            />
             <!-- 预览区域：与 BaseSelect 同结构同样式，避免切换策略时布局跳动 -->
-            <div v-else-if="localSettings.plantingStrategy !== 'bag_priority'" class="flex flex-col gap-1.5">
+            <div v-else class="flex flex-col gap-1.5">
               <label class="text-sm text-gray-700 font-medium dark:text-gray-300">策略选种预览</label>
               <div
                 class="w-full flex items-center justify-between border border-gray-200 rounded-lg bg-gray-50 px-3 py-2 text-gray-500 dark:border-gray-600 dark:bg-gray-800/50 dark:text-gray-400"
@@ -952,18 +991,18 @@ async function handleTestOffline() {
           </div>
 
           <!-- 背包种子优先级列表 -->
-          <div v-if="localSettings.plantingStrategy === 'bag_priority'" class="mt-3">
-            <div class="flex items-center justify-between mb-2">
+          <div v-if="isBagPriorityStrategy" class="mt-3">
+            <div class="mb-2 flex items-center justify-between">
               <label class="text-sm text-gray-700 font-medium dark:text-gray-300">背包种子优先级</label>
               <div class="flex items-center gap-2">
                 <button
-                  class="text-xs text-blue-500 hover:text-blue-600 dark:text-blue-400"
+                  class="text-xs text-blue-500 dark:text-blue-400 hover:text-blue-600"
                   @click="fetchBagSeeds"
                 >
                   刷新
                 </button>
                 <button
-                  class="text-xs text-gray-500 hover:text-gray-600 dark:text-gray-400"
+                  class="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-600"
                   @click="resetBagSeedPriority"
                 >
                   重置排序
@@ -971,18 +1010,18 @@ async function handleTestOffline() {
               </div>
             </div>
 
-            <div v-if="bagSeedsLoading" class="text-center py-4 text-gray-500">
+            <div v-if="bagSeedsLoading" class="py-4 text-center text-gray-500">
               加载中...
             </div>
-            <div v-else-if="sortedBagSeeds.length === 0" class="text-center py-4 text-gray-500 dark:text-gray-400">
+            <div v-else-if="sortedBagSeeds.length === 0" class="py-4 text-center text-gray-500 dark:text-gray-400">
               背包中暂无种子
             </div>
-            <div v-else class="space-y-1 max-h-64 overflow-y-auto">
+            <div v-else class="max-h-64 overflow-y-auto space-y-1">
               <div
                 v-for="(seed, index) in sortedBagSeeds"
                 :key="seed.seedId"
                 draggable="true"
-                class="flex items-center gap-3 p-2 border rounded-lg cursor-grab select-none border-gray-200 bg-gray-50 dark:border-gray-600 dark:bg-gray-800/50"
+                class="flex cursor-grab select-none items-center gap-3 border border-gray-200 rounded-lg bg-gray-50 p-2 dark:border-gray-600 dark:bg-gray-800/50"
                 @dragstart="onDragStart($event, index)"
                 @dragover="onDragOver"
                 @drop="onDrop(index)"
@@ -996,16 +1035,16 @@ async function handleTestOffline() {
                   v-if="seed.image"
                   :src="seed.image"
                   :alt="seed.name"
-                  class="w-8 h-8 object-contain pointer-events-none"
+                  class="pointer-events-none h-8 w-8 object-contain"
                 >
-                <div v-else class="w-8 h-8 bg-gray-200 rounded dark:bg-gray-700 pointer-events-none" />
-                <div class="flex-1 min-w-0 pointer-events-none">
+                <div v-else class="pointer-events-none h-8 w-8 rounded bg-gray-200 dark:bg-gray-700" />
+                <div class="pointer-events-none min-w-0 flex-1">
                   <div class="flex items-center gap-2">
                     <span
                       v-if="seed.requiredLevel >= 200"
-                      class="px-1.5 py-0.5 text-xs bg-yellow-100 text-yellow-700 rounded dark:bg-yellow-900/50 dark:text-yellow-400"
+                      class="rounded bg-yellow-100 px-1.5 py-0.5 text-xs text-yellow-700 dark:bg-yellow-900/50 dark:text-yellow-400"
                     >活动</span>
-                    <span class="text-sm font-medium text-gray-800 dark:text-gray-200 truncate">{{ seed.name }}</span>
+                    <span class="truncate text-sm text-gray-800 font-medium dark:text-gray-200">{{ seed.name }}</span>
                   </div>
                   <div class="text-xs text-gray-500 dark:text-gray-400">
                     数量: {{ seed.count }} | {{ seed.requiredLevel >= 200 ? '活动种子' : `${seed.requiredLevel}级` }}
@@ -1014,14 +1053,14 @@ async function handleTestOffline() {
                 </div>
                 <div class="flex flex-col gap-1">
                   <button
-                    class="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30"
+                    class="p-1 text-gray-400 hover:text-gray-600 disabled:opacity-30 dark:hover:text-gray-300"
                     :disabled="index === 0"
                     @click.stop="moveSeedUp(index)"
                   >
                     <div class="i-carbon-chevron-up" />
                   </button>
                   <button
-                    class="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 disabled:opacity-30"
+                    class="p-1 text-gray-400 hover:text-gray-600 disabled:opacity-30 dark:hover:text-gray-300"
                     :disabled="index === sortedBagSeeds.length - 1"
                     @click.stop="moveSeedDown(index)"
                   >
@@ -1030,10 +1069,10 @@ async function handleTestOffline() {
                 </div>
               </div>
             </div>
-            <div class="mt-2 text-xs text-gray-500 dark:text-gray-400 space-y-1">
+            <div class="mt-2 text-xs text-gray-500 space-y-1 dark:text-gray-400">
               <p>* 拖拽或点击箭头调整种植优先级</p>
               <p>* 仅支持 1x1 种子，2x2 及以上种子会被跳过</p>
-              <p>* 1x1 种子用完后将自动切换为"最高等级"策略</p>
+              <p>* 背包种子不足后，会按“第二优先策略”继续补种</p>
             </div>
           </div>
 
@@ -1138,7 +1177,7 @@ async function handleTestOffline() {
             <div class="border border-blue-200 rounded-lg bg-blue-50/70 p-3 text-gray-800 shadow-sm dark:border-blue-500/50 dark:bg-[#17243a] dark:text-white">
               <div class="mb-1 flex items-center justify-between gap-3">
                 <div class="min-w-0 flex items-center gap-2">
-                  <div class="h-9 w-9 flex items-center justify-center rounded-lg border border-blue-300/70 bg-white/90 dark:border-blue-500/40 dark:bg-blue-500/20">
+                  <div class="h-9 w-9 flex items-center justify-center border border-blue-300/70 rounded-lg bg-white/90 dark:border-blue-500/40 dark:bg-blue-500/20">
                     <div class="i-carbon-filter text-xl text-blue-700 dark:text-blue-200" />
                   </div>
                   <div class="min-w-0">
@@ -1146,7 +1185,7 @@ async function handleTestOffline() {
                       <div class="truncate text-base font-semibold">
                         排除作物
                       </div>
-                      <div class="rounded-full border border-blue-300 bg-white/95 px-2 py-0.5 text-xs text-blue-700 shadow-sm dark:border-blue-300/60 dark:bg-blue-500/15 dark:text-blue-100">
+                      <div class="border border-blue-300 rounded-full bg-white/95 px-2 py-0.5 text-xs text-blue-700 shadow-sm dark:border-blue-300/60 dark:bg-blue-500/15 dark:text-blue-100">
                         <span class="font-semibold">{{ stealBlacklistCount }} / {{ stealCropOptions.length }}</span>
                       </div>
                     </div>
@@ -1157,7 +1196,7 @@ async function handleTestOffline() {
                 </div>
                 <button
                   type="button"
-                  class="h-9 w-9 flex items-center justify-center rounded-lg border border-blue-300/70 bg-white/90 text-blue-700 transition hover:bg-blue-100 dark:border-blue-500/40 dark:bg-blue-500/20 dark:text-blue-100 dark:hover:bg-blue-500/30"
+                  class="h-9 w-9 flex items-center justify-center border border-blue-300/70 rounded-lg bg-white/90 text-blue-700 transition dark:border-blue-500/40 dark:bg-blue-500/20 hover:bg-blue-100 dark:text-blue-100 dark:hover:bg-blue-500/30"
                   :aria-expanded="!stealBlacklistCollapsed"
                   @click="stealBlacklistCollapsed = !stealBlacklistCollapsed"
                 >
@@ -1179,7 +1218,7 @@ async function handleTestOffline() {
                     <BaseButton
                       variant="outline"
                       size="sm"
-                      class="!border-blue-300 !text-blue-700 hover:!bg-blue-100 dark:!border-blue-400/70 dark:!text-blue-100 dark:hover:!bg-blue-500/20"
+                      class="!border-blue-300 !text-blue-700 dark:!border-blue-400/70 hover:!bg-blue-100 dark:!text-blue-100 dark:hover:!bg-blue-500/20"
                       :disabled="stealBlacklistCount >= stealCropOptions.length"
                       @click="filterUnselectedStealCrops"
                     >
@@ -1198,58 +1237,60 @@ async function handleTestOffline() {
                 </div>
 
                 <div class="relative mb-2">
-                  <div class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-base text-blue-500/70 dark:text-blue-200/70">
+                  <div class="pointer-events-none absolute left-3 top-1/2 text-base text-blue-500/70 -translate-y-1/2 dark:text-blue-200/70">
                     <div class="i-carbon-search" />
                   </div>
                   <input
                     v-model="stealBlacklistSearch"
                     type="text"
                     placeholder="搜索作物名或 Seed ID"
-                    class="w-full border border-blue-200 rounded-lg bg-white py-2 pl-9 pr-3 text-sm text-gray-700 outline-none placeholder:text-gray-400 focus:border-blue-400 focus:ring-2 focus:ring-blue-300/20 dark:border-blue-400/40 dark:bg-[#1c2b45] dark:text-blue-50 dark:placeholder:text-blue-200/50 dark:focus:border-blue-300/70"
+                    class="w-full border border-blue-200 rounded-lg bg-white py-2 pl-9 pr-3 text-sm text-gray-700 outline-none dark:border-blue-400/40 focus:border-blue-400 dark:bg-[#1c2b45] dark:text-blue-50 placeholder:text-gray-400 focus:ring-2 focus:ring-blue-300/20 dark:focus:border-blue-300/70 dark:placeholder:text-blue-200/50"
                   >
                 </div>
 
-              <div v-if="stealCropOptions.length > 0">
-                <div
-                  v-if="filteredStealCropOptions.length > 0"
-                  class="max-h-56 grid grid-cols-1 gap-2 overflow-y-auto pr-1 sm:grid-cols-2 lg:grid-cols-3"
-                >
-                  <button
-                    v-for="crop in filteredStealCropOptions"
-                    :key="crop.plantId"
-                    type="button"
-                    class="flex w-full cursor-pointer items-center gap-2 rounded border bg-white px-2 py-1.5 text-left text-xs text-gray-700 transition dark:bg-gray-800 dark:text-gray-300"
-                    :class="isCropBlacklisted(crop.plantId)
-                      ? 'border-blue-500 ring-1 ring-blue-300/70 dark:border-blue-400 dark:ring-blue-700/50'
-                      : 'border-gray-200 hover:border-blue-300 dark:border-gray-700 dark:hover:border-blue-700'"
-                    :aria-pressed="isCropBlacklisted(crop.plantId)"
-                    @click="toggleStealBlacklistCrop(crop.plantId)"
+                <div v-if="stealCropOptions.length > 0">
+                  <div
+                    v-if="filteredStealCropOptions.length > 0"
+                    class="grid grid-cols-1 max-h-56 gap-2 overflow-y-auto pr-1 lg:grid-cols-3 sm:grid-cols-2"
                   >
-                    <img
-                      v-if="crop.image"
-                      :src="crop.image"
-                      :alt="crop.name"
-                      class="h-[1.8rem] w-[1.8rem] rounded object-cover"
+                    <button
+                      v-for="crop in filteredStealCropOptions"
+                      :key="crop.plantId"
+                      type="button"
+                      class="w-full flex cursor-pointer items-center gap-2 border rounded bg-white px-2 py-1.5 text-left text-xs text-gray-700 transition dark:bg-gray-800 dark:text-gray-300"
+                      :class="isCropBlacklisted(crop.plantId)
+                        ? 'border-blue-500 ring-1 ring-blue-300/70 dark:border-blue-400 dark:ring-blue-700/50'
+                        : 'border-gray-200 hover:border-blue-300 dark:border-gray-700 dark:hover:border-blue-700'"
+                      :aria-pressed="isCropBlacklisted(crop.plantId)"
+                      @click="toggleStealBlacklistCrop(crop.plantId)"
                     >
-                    <div v-else class="h-[1.8rem] w-[1.8rem] flex items-center justify-center rounded bg-gray-100 text-[10px] text-gray-500 dark:bg-gray-700 dark:text-gray-400">
-                      <div class="i-carbon-image" />
-                    </div>
-                    <div class="min-w-0 flex-1">
-                      <div class="truncate text-xs font-medium">{{ crop.name }}</div>
-                      <div class="text-[11px] text-gray-500 dark:text-gray-400">
-                        Seed ID: {{ crop.seedId === null ? '?' : crop.seedId }}   Lv.{{ crop.level === null ? '?' : crop.level }}
+                      <img
+                        v-if="crop.image"
+                        :src="crop.image"
+                        :alt="crop.name"
+                        class="h-[1.8rem] w-[1.8rem] rounded object-cover"
+                      >
+                      <div v-else class="h-[1.8rem] w-[1.8rem] flex items-center justify-center rounded bg-gray-100 text-[10px] text-gray-500 dark:bg-gray-700 dark:text-gray-400">
+                        <div class="i-carbon-image" />
                       </div>
-                    </div>
-                  </button>
+                      <div class="min-w-0 flex-1">
+                        <div class="truncate text-xs font-medium">
+                          {{ crop.name }}
+                        </div>
+                        <div class="text-[11px] text-gray-500 dark:text-gray-400">
+                          Seed ID: {{ crop.seedId === null ? '?' : crop.seedId }}   Lv.{{ crop.level === null ? '?' : crop.level }}
+                        </div>
+                      </div>
+                    </button>
+                  </div>
+                  <div v-else class="rounded bg-white px-2 py-2 text-xs text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+                    未找到匹配作物，请调整关键词后重试。
+                  </div>
                 </div>
                 <div v-else class="rounded bg-white px-2 py-2 text-xs text-gray-500 dark:bg-gray-800 dark:text-gray-400">
-                  未找到匹配作物，请调整关键词后重试。
+                  暂无可选作物，请先等待种子列表加载完成。
                 </div>
               </div>
-              <div v-else class="rounded bg-white px-2 py-2 text-xs text-gray-500 dark:bg-gray-800 dark:text-gray-400">
-                暂无可选作物，请先等待种子列表加载完成。
-              </div>
-            </div>
             </div>
             <div class="border border-amber-200 rounded bg-amber-50/60 p-3 dark:border-amber-800/60 dark:bg-amber-900/10">
               <div class="mb-2 text-sm text-amber-800 font-medium dark:text-amber-300">
@@ -1602,15 +1643,15 @@ async function handleTestOffline() {
               type="text"
               :value="token"
               readonly
-              class="flex-1 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
-            />
+              class="flex-1 border border-gray-200 rounded-lg bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+            >
             <BaseButton
               v-if="token !== '未登录'"
               variant="secondary"
               size="sm"
               @click="copyToClipboard(token)"
             >
-              <div class="i-carbon-copy mr-1"></div>
+              <div class="i-carbon-copy mr-1" />
               复制
             </BaseButton>
           </div>


### PR DESCRIPTION
## 背景

当前“优先背包种子”策略在背包种子不足或没有可用 1x1 种子时，会直接回退到固定的“最高等级作物”策略。

这样一来，用户无法按自己的习惯指定后续补种方式，运行中修改背包排序后也缺少完整的配置同步字段。

## 变更内容

- 新增账号配置 `bagSeedFallbackStrategy`，旧配置升级后会自动初始化默认值 `level`
- 设置页在“优先背包种子”下增加“第二优先策略”选择项
- 农场种植逻辑改为：先按背包优先级消耗可用的 1x1 种子，背包不足时再按第二优先策略从商店补种
- 补齐设置接口和运行时配置快照中的 `bagSeedPriority` / `bagSeedFallbackStrategy` 字段，保证运行中保存后 worker 可及时感知

## 预期效果

- 背包种子用完后不再固定回退到“最高等级作物”
- 用户可以按账号单独配置背包不足时的补种策略
- 老版本升级到新版本后，新增配置会自动补默认值，不需要手动初始化
- 运行中修改背包排序或第二优先策略后，无需重启即可生效

## 影响文件

- `core/src/models/store.js`
- `core/src/runtime/data-provider.js`
- `core/src/runtime/runtime-state.js`
- `core/src/services/farm.js`
- `core/src/controllers/admin.js`
- `web/src/stores/setting.ts`
- `web/src/views/Settings.vue`

## 验证

- `pnpm lint`
- `pnpm build:web`