### PR TITLE
fix(farm): 调整个人农场地块布局并补齐好友季数显示

### DIFF
--- a/core/src/services/friend.js
+++ b/core/src/services/friend.js
@@ -750,6 +750,8 @@ async function getFriendLandsDetail(friendGid) {
                     plantName: '',
                     phaseName: '未解锁',
                     level,
+                    currentSeason: 0,
+                    totalSeason: 0,
                     needWater: false,
                     needWeed: false,
                     needBug: false,
@@ -769,6 +771,8 @@ async function getFriendLandsDetail(friendGid) {
                     plantName: '',
                     phaseName: '空地',
                     level,
+                    currentSeason: 0,
+                    totalSeason: 0,
                     occupiedByMaster,
                     masterLandId,
                     occupiedLandIds,
@@ -785,6 +789,8 @@ async function getFriendLandsDetail(friendGid) {
                     plantName: '',
                     phaseName: '',
                     level,
+                    currentSeason: 0,
+                    totalSeason: 0,
                     occupiedByMaster,
                     masterLandId,
                     occupiedLandIds,
@@ -799,6 +805,9 @@ async function getFriendLandsDetail(friendGid) {
             const seedId = toNum(plantCfg && plantCfg.seed_id);
             const seedImage = seedId > 0 ? getSeedImageBySeedId(seedId) : '';
             const plantSize = Math.max(1, toNum(plantCfg && plantCfg.size) || 1);
+            const totalSeason = Math.max(1, toNum(plantCfg && plantCfg.seasons) || 1);
+            const currentSeasonRaw = toNum(plant.season);
+            const currentSeason = currentSeasonRaw > 0 ? Math.min(currentSeasonRaw, totalSeason) : 1;
             const phaseName = PHASE_NAMES[phaseVal] || '';
             const maturePhase = Array.isArray(plant.phases)
                 ? plant.phases.find((p) => p && toNum(p.phase) === PlantPhase.MATURE)
@@ -818,6 +827,8 @@ async function getFriendLandsDetail(friendGid) {
                 seedImage,
                 phaseName,
                 level,
+                currentSeason,
+                totalSeason,
                 matureInSec,
                 needWater: toNum(plant.dry_num) > 0,
                 needWeed: (plant.weed_owners && plant.weed_owners.length > 0),

--- a/web/src/components/FarmPanel.vue
+++ b/web/src/components/FarmPanel.vue
@@ -77,9 +77,10 @@ const displayLands = computed(() => {
   const rows = Math.ceil(list.length / columns)
   const ordered: any[] = []
 
-  // Convert source data into the same top-to-bottom, left-to-right order the CSS grid uses.
+  // Farm land ids are numbered from the top-right corner downward in each column.
+  // Reorder the cards so the rendered grid matches the in-game layout.
   for (let row = 0; row < rows; row++) {
-    for (let col = 0; col < columns; col++) {
+    for (let col = columns - 1; col >= 0; col--) {
       const index = col * rows + row
       if (index < list.length)
         ordered.push(list[index])


### PR DESCRIPTION
## 背景

当前农场相关页面主要有两个问题：

* 个人农场在桌面端的地块展示顺序与游戏内实际布局不一致
* 好友农场土地卡片的“季数”始终显示为 `-/-`，因为好友详情接口没有返回对应字段

## 变更内容

### 1. 调整个人农场桌面端地块布局

* 按游戏内实际地块编号方式重新排列个人农场土地卡片
* 改为从右上角开始，按列自上而下对应地块编号
* 调整的是整张土地卡片的位置，而不是只修改编号文本

### 2. 补齐好友农场季数字段

* 在好友土地详情接口中补充 `currentSeason` 与 `totalSeason`
* 对未解锁、空地等无作物场景返回默认季数值
* 与个人农场土地卡片使用的字段保持一致，避免前端继续显示 `-/-`

## 预期效果

* 个人农场地块布局与游戏内编号顺序一致
* 用户可以更直观地按地块编号定位目标土地
* 好友农场土地卡片可以正常显示季数
* 不影响好友栏现有的展示布局与交互方式

## 影响文件

### 前端

* `web/src/components/FarmPanel.vue`

### 后端

* `core/src/services/friend.js`

## 验证

已验证：

* 个人农场页面地块顺序已按预期调整
* 好友土地详情接口已返回 `currentSeason` 和 `totalSeason`
* 好友农场页面季数可正常显示
* 前端构建通过
* 后端修改可独立生效，不依赖好友栏布局调整
