### PR TITLE
feat(farm): 调整土地升级顺序，优先 2x2 连块升级

### DIFF
--- a/core/src/services/farm.js
+++ b/core/src/services/farm.js
@@ -1190,6 +1190,41 @@ function sortBagSeedsByPriority(bagSeeds, priority) {
 /**
  * 从商店购买种子并种植
  */
+const FARM_LAYOUT_ROWS = 4;
+
+function getLandGridPosition(landId) {
+    const id = toNum(landId);
+    if (id <= 0) return null;
+
+    const zeroBased = id - 1;
+    return {
+        row: zeroBased % FARM_LAYOUT_ROWS,
+        col: Math.floor(zeroBased / FARM_LAYOUT_ROWS),
+    };
+}
+
+function getLandUpgradePriority(landId) {
+    const pos = getLandGridPosition(landId);
+    if (!pos) return Number.MAX_SAFE_INTEGER;
+
+    const groupCol = Math.floor(pos.col / 2);
+    const groupRow = Math.floor(pos.row / 2);
+    const groupsPerColumnPair = Math.ceil(FARM_LAYOUT_ROWS / 2);
+    const groupIndex = groupCol * groupsPerColumnPair + groupRow;
+    const withinGroupIndex = (pos.col % 2) * 2 + (pos.row % 2);
+
+    return groupIndex * 4 + withinGroupIndex;
+}
+
+function sortLandIdsForUpgrade(landIds) {
+    const ids = Array.isArray(landIds) ? landIds.map(id => toNum(id)).filter(Boolean) : [];
+    return ids.sort((a, b) => {
+        const priorityDiff = getLandUpgradePriority(a) - getLandUpgradePriority(b);
+        if (priorityDiff !== 0) return priorityDiff;
+        return a - b;
+    });
+}
+
 async function plantFromShop(landsToPlant, state) {
     let bestSeed;
     try {
@@ -1695,7 +1730,8 @@ async function runFarmOperation(opType, options = {}) {
 
         if (status.upgradable.length > 0) {
             let upgraded = 0;
-            for (const landId of status.upgradable) {
+            const sortedUpgradableLandIds = sortLandIdsForUpgrade(status.upgradable);
+            for (const landId of sortedUpgradableLandIds) {
                 try {
                     const reply = await upgradeLand(landId);
                     const newLevel = reply.land ? toNum(reply.land.level) : '?';


### PR DESCRIPTION
## 背景

当前土地升级的主要问题是：

* 可升级土地默认按地块编号顺序升级
* 升级顺序不利于优先形成 2x2 连块高等级土地
* 在需要种植 2x2 作物时，往往不能优先把相邻地块一起升起来

以当前农场布局为例，期望优先升级的顺序应更接近：

* `#1 #2 #5 #6`
* 而不是单纯按 `#1 #2 #3 #4 ...`

## 变更内容
### 1. 新增土地布局优先级计算
* 基于农场固定布局（6 列 x 4 行）计算每块土地在网格中的位置
* 按 2x2 小方块分组生成升级优先级

### 2. 调整土地升级排序逻辑
* 升级前先对 `status.upgradable` 做排序
* 同一组内优先顺序为：
  * `#1 #2 #5 #6`
  * `#3 #4 #7 #8`
  * 后续分组依次类推

### 3. 保持现有升级接口不变
* 不修改 `upgradeLand` 调用方式
* 不修改升级成功/失败日志结构
* 仅调整升级目标的执行顺序

## 预期效果

* 更容易优先形成 2x2 连块高等级土地
* 更符合 2x2 作物种植需求
* 不影响现有一键升级入口和自动升级开关
* 对已有升级流程兼容，风险较低

## 影响文件

### 后端

* `core/src/services/farm.js`

## 验证

已验证：

* 后端语法检查通过
* 升级排序结果已按预期变为：
  * `1,2,5,6,3,4,7,8,9,10,13,14,11,12,15,16,17,18,21,22,19,20,23,24`
* 第一组优先顺序确认符合预期：
  * `#1 #2 #5 #6`
* 该改动仅调整升级顺序，不依赖前端变更
